### PR TITLE
Add constructors for `string_t` and `error_t` and remove implicit saves

### DIFF
--- a/test/test.f90
+++ b/test/test.f90
@@ -914,7 +914,7 @@ program test
 contains
 
   subroutine fail(msg)
-    character(len=*), intent(in) :: msg
+    character(*), intent(in) :: msg
     print *, achar(27)//'[31m'//'Test failed: '//msg//achar(27)//'[0m'
     stop 1
   end


### PR DESCRIPTION
- [x] Fix tests by adding constructors for `string_t` and `error_t`.
- [x] Remove implicit `save`s in variable declarations.