### PR TITLE
Add version constraints

### DIFF
--- a/src/version_f.f90
+++ b/src/version_f.f90
@@ -24,7 +24,7 @@ module version_f
   contains
 
     procedure :: to_string, increment_major, increment_minor, increment_patch, &
-    & increment_prerelease, increment_build, is_exactly, satisfies
+    & increment_prerelease, increment_build, is_exactly, satisfies, try_satisfy
 
     generic :: create => try_create
     procedure, private :: try_create
@@ -727,7 +727,7 @@ contains
   !>   type(error_t), allocatable :: error
   !>
   !>   version = version_t(1, 2, 3)
-  !>   call version%satisfies(requirement, is_satisfied, error)
+  !>   call version%try_satisfy(requirement, is_satisfied, error)
   !>   if (allocated(error)) return
   !>
   !>   if (is_satisfied) then
@@ -736,7 +736,7 @@ contains
   !>     print *, "Version '", version%to_string(), "' does not meet the requirement '", requirement, "'."
   !>   end if
   !> end
-  subroutine satisfies(this, string, result, error)
+  subroutine try_satisfy(this, string, result, error)
     class(version_t), intent(in) :: this
 
     !> Input string to be evaluated.
@@ -796,5 +796,22 @@ contains
     call parsed_version%parse(str, error)
     if (allocated(error)) return
     result = this == parsed_version
+  end
+
+  !> Convenience function to determine whether the version meets the comparison.
+  !>
+  !> This function is a wrapper around `try_satisfy`. It returns `.false.` if
+  !> the comparison fails.
+  logical function satisfies(this, str)
+    !> Instance of `version_t` to be evaluated.
+    class(version_t), intent(in) :: this
+
+    !> Input string to be evaluated.
+    character(*), intent(in) :: str
+
+    type(error_t), allocatable :: error
+
+    call this%try_satisfy(str, satisfies, error)
+    if (allocated(error)) satisfies = .false.
   end
 end

--- a/src/version_f.f90
+++ b/src/version_f.f90
@@ -311,13 +311,16 @@ contains
   !> Attempt to parse a string into a version including prerelease and build
   !> data. In strict mode, all major, minor and patch versions must be provided.
   !> Implicit zeros are forbidden in strict mode.
-  subroutine try_parse(this, str, error, strict_mode)
+  subroutine try_parse(this, string, error, strict_mode)
     class(version_t), intent(out) :: this
-    character(*), intent(in) :: str
+    character(*), intent(in) :: string
     type(error_t), allocatable, intent(out) :: error
     logical, optional, intent(in) :: strict_mode
 
     integer :: i, j
+    character(:), allocatable :: str
+
+    str = trim(adjustl(string))
 
     i = index(str, '-')
     j = index(str, '+')

--- a/test/test.f90
+++ b/test/test.f90
@@ -1,8 +1,10 @@
 program test
   use version_f, only: version_t, is_version, error_t
+
   implicit none
 
   type(version_t) :: v1, v2
+  logical :: is_satisfied
   type(error_t), allocatable :: e
 
 !################################### Create ###################################!
@@ -910,6 +912,168 @@ program test
   if (.not. is_version('1.0.0+123', strict_mode=.true.)) call fail("Strict mode: Is valid version.")
   if (.not. is_version('1.0.0+123', strict_mode=.false.)) call fail("No strict mode: Is valid version.")
   if (.not. is_version('11.0', strict_mode=.false.)) call fail("No strict mode: Is valid version.")
+
+  !##################################satisfies#################################!
+
+  v1 = version_t(0, 1, 0)
+  call v1%satisfies('', is_satisfied, e)
+  if (.not. allocated(e)) call fail('satisfy-1 should fail.')
+
+  v1 = version_t(0, 1, 0)
+  call v1%satisfies(' ', is_satisfied, e)
+  if (.not. allocated(e)) call fail('satisfy-2 should fail.')
+
+  v1 = version_t(0, 1, 0)
+  call v1%satisfies('0.1.0', is_satisfied, e)
+  if (.not. is_satisfied) call fail('satisfy-3 should satisfy.')
+  if (allocated(e)) call fail('satisfy-3 should not fail.')
+
+  v1 = version_t(0, 1, 0, 'abc')
+  call v1%satisfies('0.1.0', is_satisfied, e)
+  if (is_satisfied) call fail('satisfy-4 should not satisfy.')
+  if (allocated(e)) call fail('satisfy-4 should not fail.')
+
+  v1 = version_t(0, 1, 0)
+  call v1%satisfies('0.1.0-abc', is_satisfied, e)
+  if (is_satisfied) call fail('satisfy-5 should not satisfy.')
+  if (allocated(e)) call fail('satisfy-5 should not fail.')
+
+  v1 = version_t(0, 1, 0, 'abc')
+  call v1%satisfies('0.1.0-cde', is_satisfied, e)
+  if (is_satisfied) call fail('satisfy-6 should not satisfy.')
+  if (allocated(e)) call fail('satisfy-6 should not fail.')
+
+  v1 = version_t(0, 1, 0, 'abc', 'cde')
+  call v1%satisfies('0.1.0-abc', is_satisfied, e)
+  if (.not. is_satisfied) call fail('satisfy-7 should satisfy.')
+  if (allocated(e)) call fail('satisfy-7 should not fail.')
+
+  v1 = version_t(0, 1, 0, 'abc', 'cde')
+  call v1%satisfies('0.1.0-abc+xyz', is_satisfied, e)
+  if (.not. is_satisfied) call fail('satisfy-8 should satisfy.')
+  if (allocated(e)) call fail('satisfy-8 should not fail.')
+
+  v1 = version_t(0, 1, 0)
+  call v1%satisfies('  0.1.0  ', is_satisfied, e)
+  if (.not. is_satisfied) call fail('satisfy-9 should satisfy.')
+  if (allocated(e)) call fail('satisfy-9 should not fail.')
+
+  v1 = version_t(0, 1, 0)
+  call v1%satisfies('  0.1.0+abc  ', is_satisfied, e)
+  if (.not. is_satisfied) call fail('satisfy-10 should satisfy.')
+  if (allocated(e)) call fail('satisfy-10 should not fail.')
+
+  v1 = version_t(0, 1, 0)
+  call v1%satisfies('0.2.0', is_satisfied, e)
+  if (is_satisfied) call fail('satisfy-11 should not satisfy.')
+  if (allocated(e)) call fail('satisfy-11 should not fail.')
+
+  v1 = version_t(0, 1, 0)
+  call v1%satisfies('0.2.0', is_satisfied, e)
+  if (is_satisfied) call fail('satisfy-12 should not satisfy.')
+  if (allocated(e)) call fail('satisfy-12 should not fail.')
+
+  v1 = version_t(0, 1, 0)
+  call v1%satisfies('=0.1.0', is_satisfied, e)
+  if (.not. is_satisfied) call fail('satisfy-13 should satisfy.')
+  if (allocated(e)) call fail('satisfy-13 should not fail.')
+
+  v1 = version_t(0, 1, 0)
+  call v1%satisfies('=   0.1.0', is_satisfied, e)
+  if (.not. is_satisfied) call fail('satisfy-14 should satisfy.')
+  if (allocated(e)) call fail('satisfy-14 should not fail.')
+
+  v1 = version_t(0, 1, 0)
+  call v1%satisfies('= 0.2.0', is_satisfied, e)
+  if (is_satisfied) call fail('satisfy-15 should not satisfy.')
+  if (allocated(e)) call fail('satisfy-15 should not fail.')
+
+  v1 = version_t(0, 1, 0)
+  call v1%satisfies('!=0.2.0', is_satisfied, e)
+  if (.not. is_satisfied) call fail('satisfy-16 should satisfy.')
+  if (allocated(e)) call fail('satisfy-16 should not fail.')
+
+  v1 = version_t(0, 1, 0)
+  call v1%satisfies('!=0.1.0', is_satisfied, e)
+  if (is_satisfied) call fail('satisfy-17 should not satisfy.')
+  if (allocated(e)) call fail('satisfy-17 should not fail.')
+
+  v1 = version_t(0, 1, 0)
+  call v1%satisfies('!= 0.1.0', is_satisfied, e)
+  if (is_satisfied) call fail('satisfy-18 should not satisfy.')
+  if (allocated(e)) call fail('satisfy-18 should not fail.')
+
+  v1 = version_t(0, 1, 0)
+  call v1%satisfies('0.1.0abcd', is_satisfied, e)
+  if (.not. allocated(e)) call fail('satisfy-19 should fail.')
+
+  v1 = version_t(0, 1, 0)
+  call v1%satisfies('=0.1.0abcd', is_satisfied, e)
+  if (.not. allocated(e)) call fail('satisfy-20 should fail.')
+
+  v1 = version_t(0, 1, 0)
+  call v1%satisfies('>0.1.0', is_satisfied, e)
+  if (is_satisfied) call fail('satisfy-20 should not satisfy.')
+  if (allocated(e)) call fail('satisfy-20 should not fail.')
+
+  v1 = version_t(0, 1, 0)
+  call v1%satisfies('>0.1.0-1', is_satisfied, e)
+  if (.not. is_satisfied) call fail('satisfy-21 should satisfy.')
+  if (allocated(e)) call fail('satisfy-21 should not fail.')
+
+  v1 = version_t(0, 1, 0)
+  call v1%satisfies('> 0.0.9', is_satisfied, e)
+  if (.not. is_satisfied) call fail('satisfy-22 should satisfy.')
+  if (allocated(e)) call fail('satisfy-22 should not fail.')
+
+  v1 = version_t(0, 1, 0)
+  call v1%satisfies('>=0.1.0', is_satisfied, e)
+  if (.not. is_satisfied) call fail('satisfy-23 should satisfy.')
+  if (allocated(e)) call fail('satisfy-23 should not fail.')
+
+  v1 = version_t(0, 1, 0)
+  call v1%satisfies('>=   0.1.0-678', is_satisfied, e)
+  if (.not. is_satisfied) call fail('satisfy-24 should satisfy.')
+  if (allocated(e)) call fail('satisfy-24 should not fail.')
+
+  v1 = version_t(0, 1, 0)
+  call v1%satisfies('>=0.1.0+123', is_satisfied, e)
+  if (.not. is_satisfied) call fail('satisfy-25 should satisfy.')
+  if (allocated(e)) call fail('satisfy-25 should not fail.')
+
+  v1 = version_t(0, 1, 0)
+  call v1%satisfies('<0.1.0', is_satisfied, e)
+  if (is_satisfied) call fail('satisfy-26 should not satisfy.')
+  if (allocated(e)) call fail('satisfy-26 should not fail.')
+
+  v1 = version_t(0, 1, 0)
+  call v1%satisfies('< 0.1.0-1', is_satisfied, e)
+  if (is_satisfied) call fail('satisfy-27 should not satisfy.')
+  if (allocated(e)) call fail('satisfy-27 should not fail.')
+
+  v1 = version_t(0, 1, 0)
+  call v1%satisfies('< 0.0.9', is_satisfied, e)
+  if (is_satisfied) call fail('satisfy-28 should not satisfy.')
+  if (allocated(e)) call fail('satisfy-28 should not fail.')
+
+  v1 = version_t(0, 1, 0)
+  call v1%satisfies('<=0.1.0', is_satisfied, e)
+  if (.not. is_satisfied) call fail('satisfy-29 should satisfy.')
+  if (allocated(e)) call fail('satisfy-29 should not fail.')
+
+  v1 = version_t(0, 1, 0)
+  call v1%satisfies('<=   0.1.0-678', is_satisfied, e)
+  if (is_satisfied) call fail('satisfy-30 should not satisfy.')
+  if (allocated(e)) call fail('satisfy-30 should not fail.')
+
+  v1 = version_t(0, 1, 0)
+  call v1%satisfies('<=0.1.0+123', is_satisfied, e)
+  if (.not. is_satisfied) call fail('satisfy-30 should satisfy.')
+  if (allocated(e)) call fail('satisfy-30 should not fail.')
+
+  v1 = version_t(0, 1, 0)
+  call v1%satisfies(' abc ', is_satisfied, e)
+  if (.not. allocated(e)) call fail('satisfy-31 should fail.')
 
 contains
 

--- a/test/test.f90
+++ b/test/test.f90
@@ -916,164 +916,182 @@ program test
   !##################################satisfies#################################!
 
   v1 = version_t(0, 1, 0)
-  call v1%satisfies('', is_satisfied, e)
+  call v1%try_satisfy('', is_satisfied, e)
   if (.not. allocated(e)) call fail('satisfy-1 should fail.')
 
   v1 = version_t(0, 1, 0)
-  call v1%satisfies(' ', is_satisfied, e)
+  call v1%try_satisfy(' ', is_satisfied, e)
   if (.not. allocated(e)) call fail('satisfy-2 should fail.')
 
   v1 = version_t(0, 1, 0)
-  call v1%satisfies('0.1.0', is_satisfied, e)
+  call v1%try_satisfy('0.1.0', is_satisfied, e)
   if (.not. is_satisfied) call fail('satisfy-3 should satisfy.')
   if (allocated(e)) call fail('satisfy-3 should not fail.')
 
   v1 = version_t(0, 1, 0, 'abc')
-  call v1%satisfies('0.1.0', is_satisfied, e)
+  call v1%try_satisfy('0.1.0', is_satisfied, e)
   if (is_satisfied) call fail('satisfy-4 should not satisfy.')
   if (allocated(e)) call fail('satisfy-4 should not fail.')
 
   v1 = version_t(0, 1, 0)
-  call v1%satisfies('0.1.0-abc', is_satisfied, e)
+  call v1%try_satisfy('0.1.0-abc', is_satisfied, e)
   if (is_satisfied) call fail('satisfy-5 should not satisfy.')
   if (allocated(e)) call fail('satisfy-5 should not fail.')
 
   v1 = version_t(0, 1, 0, 'abc')
-  call v1%satisfies('0.1.0-cde', is_satisfied, e)
+  call v1%try_satisfy('0.1.0-cde', is_satisfied, e)
   if (is_satisfied) call fail('satisfy-6 should not satisfy.')
   if (allocated(e)) call fail('satisfy-6 should not fail.')
 
   v1 = version_t(0, 1, 0, 'abc', 'cde')
-  call v1%satisfies('0.1.0-abc', is_satisfied, e)
+  call v1%try_satisfy('0.1.0-abc', is_satisfied, e)
   if (.not. is_satisfied) call fail('satisfy-7 should satisfy.')
   if (allocated(e)) call fail('satisfy-7 should not fail.')
 
   v1 = version_t(0, 1, 0, 'abc', 'cde')
-  call v1%satisfies('0.1.0-abc+xyz', is_satisfied, e)
+  call v1%try_satisfy('0.1.0-abc+xyz', is_satisfied, e)
   if (.not. is_satisfied) call fail('satisfy-8 should satisfy.')
   if (allocated(e)) call fail('satisfy-8 should not fail.')
 
   v1 = version_t(0, 1, 0)
-  call v1%satisfies('  0.1.0  ', is_satisfied, e)
+  call v1%try_satisfy('  0.1.0  ', is_satisfied, e)
   if (.not. is_satisfied) call fail('satisfy-9 should satisfy.')
   if (allocated(e)) call fail('satisfy-9 should not fail.')
 
   v1 = version_t(0, 1, 0)
-  call v1%satisfies('  0.1.0+abc  ', is_satisfied, e)
+  call v1%try_satisfy('  0.1.0+abc  ', is_satisfied, e)
   if (.not. is_satisfied) call fail('satisfy-10 should satisfy.')
   if (allocated(e)) call fail('satisfy-10 should not fail.')
 
   v1 = version_t(0, 1, 0)
-  call v1%satisfies('0.2.0', is_satisfied, e)
+  call v1%try_satisfy('0.2.0', is_satisfied, e)
   if (is_satisfied) call fail('satisfy-11 should not satisfy.')
   if (allocated(e)) call fail('satisfy-11 should not fail.')
 
   v1 = version_t(0, 1, 0)
-  call v1%satisfies('0.2.0', is_satisfied, e)
+  call v1%try_satisfy('0.2.0', is_satisfied, e)
   if (is_satisfied) call fail('satisfy-12 should not satisfy.')
   if (allocated(e)) call fail('satisfy-12 should not fail.')
 
   v1 = version_t(0, 1, 0)
-  call v1%satisfies('=0.1.0', is_satisfied, e)
+  call v1%try_satisfy('=0.1.0', is_satisfied, e)
   if (.not. is_satisfied) call fail('satisfy-13 should satisfy.')
   if (allocated(e)) call fail('satisfy-13 should not fail.')
 
   v1 = version_t(0, 1, 0)
-  call v1%satisfies('=   0.1.0', is_satisfied, e)
+  call v1%try_satisfy('=   0.1.0', is_satisfied, e)
   if (.not. is_satisfied) call fail('satisfy-14 should satisfy.')
   if (allocated(e)) call fail('satisfy-14 should not fail.')
 
   v1 = version_t(0, 1, 0)
-  call v1%satisfies('= 0.2.0', is_satisfied, e)
+  call v1%try_satisfy('= 0.2.0', is_satisfied, e)
   if (is_satisfied) call fail('satisfy-15 should not satisfy.')
   if (allocated(e)) call fail('satisfy-15 should not fail.')
 
   v1 = version_t(0, 1, 0)
-  call v1%satisfies('!=0.2.0', is_satisfied, e)
+  call v1%try_satisfy('!=0.2.0', is_satisfied, e)
   if (.not. is_satisfied) call fail('satisfy-16 should satisfy.')
   if (allocated(e)) call fail('satisfy-16 should not fail.')
 
   v1 = version_t(0, 1, 0)
-  call v1%satisfies('!=0.1.0', is_satisfied, e)
+  call v1%try_satisfy('!=0.1.0', is_satisfied, e)
   if (is_satisfied) call fail('satisfy-17 should not satisfy.')
   if (allocated(e)) call fail('satisfy-17 should not fail.')
 
   v1 = version_t(0, 1, 0)
-  call v1%satisfies('!= 0.1.0', is_satisfied, e)
+  call v1%try_satisfy('!= 0.1.0', is_satisfied, e)
   if (is_satisfied) call fail('satisfy-18 should not satisfy.')
   if (allocated(e)) call fail('satisfy-18 should not fail.')
 
   v1 = version_t(0, 1, 0)
-  call v1%satisfies('0.1.0abcd', is_satisfied, e)
+  call v1%try_satisfy('0.1.0abcd', is_satisfied, e)
   if (.not. allocated(e)) call fail('satisfy-19 should fail.')
 
   v1 = version_t(0, 1, 0)
-  call v1%satisfies('=0.1.0abcd', is_satisfied, e)
+  call v1%try_satisfy('=0.1.0abcd', is_satisfied, e)
   if (.not. allocated(e)) call fail('satisfy-20 should fail.')
 
   v1 = version_t(0, 1, 0)
-  call v1%satisfies('>0.1.0', is_satisfied, e)
+  call v1%try_satisfy('>0.1.0', is_satisfied, e)
   if (is_satisfied) call fail('satisfy-20 should not satisfy.')
   if (allocated(e)) call fail('satisfy-20 should not fail.')
 
   v1 = version_t(0, 1, 0)
-  call v1%satisfies('>0.1.0-1', is_satisfied, e)
+  call v1%try_satisfy('>0.1.0-1', is_satisfied, e)
   if (.not. is_satisfied) call fail('satisfy-21 should satisfy.')
   if (allocated(e)) call fail('satisfy-21 should not fail.')
 
   v1 = version_t(0, 1, 0)
-  call v1%satisfies('> 0.0.9', is_satisfied, e)
+  call v1%try_satisfy('> 0.0.9', is_satisfied, e)
   if (.not. is_satisfied) call fail('satisfy-22 should satisfy.')
   if (allocated(e)) call fail('satisfy-22 should not fail.')
 
   v1 = version_t(0, 1, 0)
-  call v1%satisfies('>=0.1.0', is_satisfied, e)
+  call v1%try_satisfy('>=0.1.0', is_satisfied, e)
   if (.not. is_satisfied) call fail('satisfy-23 should satisfy.')
   if (allocated(e)) call fail('satisfy-23 should not fail.')
 
   v1 = version_t(0, 1, 0)
-  call v1%satisfies('>=   0.1.0-678', is_satisfied, e)
+  call v1%try_satisfy('>=   0.1.0-678', is_satisfied, e)
   if (.not. is_satisfied) call fail('satisfy-24 should satisfy.')
   if (allocated(e)) call fail('satisfy-24 should not fail.')
 
   v1 = version_t(0, 1, 0)
-  call v1%satisfies('>=0.1.0+123', is_satisfied, e)
+  call v1%try_satisfy('>=0.1.0+123', is_satisfied, e)
   if (.not. is_satisfied) call fail('satisfy-25 should satisfy.')
   if (allocated(e)) call fail('satisfy-25 should not fail.')
 
   v1 = version_t(0, 1, 0)
-  call v1%satisfies('<0.1.0', is_satisfied, e)
+  call v1%try_satisfy('<0.1.0', is_satisfied, e)
   if (is_satisfied) call fail('satisfy-26 should not satisfy.')
   if (allocated(e)) call fail('satisfy-26 should not fail.')
 
   v1 = version_t(0, 1, 0)
-  call v1%satisfies('< 0.1.0-1', is_satisfied, e)
+  call v1%try_satisfy('< 0.1.0-1', is_satisfied, e)
   if (is_satisfied) call fail('satisfy-27 should not satisfy.')
   if (allocated(e)) call fail('satisfy-27 should not fail.')
 
   v1 = version_t(0, 1, 0)
-  call v1%satisfies('< 0.0.9', is_satisfied, e)
+  call v1%try_satisfy('< 0.0.9', is_satisfied, e)
   if (is_satisfied) call fail('satisfy-28 should not satisfy.')
   if (allocated(e)) call fail('satisfy-28 should not fail.')
 
   v1 = version_t(0, 1, 0)
-  call v1%satisfies('<=0.1.0', is_satisfied, e)
+  call v1%try_satisfy('<=0.1.0', is_satisfied, e)
   if (.not. is_satisfied) call fail('satisfy-29 should satisfy.')
   if (allocated(e)) call fail('satisfy-29 should not fail.')
 
   v1 = version_t(0, 1, 0)
-  call v1%satisfies('<=   0.1.0-678', is_satisfied, e)
+  call v1%try_satisfy('<=   0.1.0-678', is_satisfied, e)
   if (is_satisfied) call fail('satisfy-30 should not satisfy.')
   if (allocated(e)) call fail('satisfy-30 should not fail.')
 
   v1 = version_t(0, 1, 0)
-  call v1%satisfies('<=0.1.0+123', is_satisfied, e)
+  call v1%try_satisfy('<=0.1.0+123', is_satisfied, e)
   if (.not. is_satisfied) call fail('satisfy-30 should satisfy.')
   if (allocated(e)) call fail('satisfy-30 should not fail.')
 
   v1 = version_t(0, 1, 0)
-  call v1%satisfies(' abc ', is_satisfied, e)
+  call v1%try_satisfy(' abc ', is_satisfied, e)
   if (.not. allocated(e)) call fail('satisfy-31 should fail.')
+
+  v1 = version_t(0, 1, 0)
+  if (v1%satisfies('  ')) call fail('satisfy-32 should fail.')
+
+  v1 = version_t(0, 1, 0)
+  if (v1%satisfies('abc')) call fail('satisfy-33 should fail.')
+
+  v1 = version_t(0, 1, 0)
+  if (.not. v1%satisfies('0.1.0')) call fail('satisfy-34 should not fail.')
+
+  v1 = version_t(0, 1, 0)
+  if (.not. v1%satisfies('>=0.1.0')) call fail('satisfy-35 should not fail.')
+
+  v1 = version_t(0, 1, 0)
+  if (v1%satisfies('>0.1.0')) call fail('satisfy-36 should fail.')
+
+  v1 = version_t(0, 1, 0)
+  if (v1%satisfies('>=0.1.0-....')) call fail('satisfy-37 should fail.')
 
 contains
 


### PR DESCRIPTION
Add version constraints and ranges using the `satisfies` and `try_satisfy` procedures, respectively.

- [x] Implement simple version constraints that have a single comparator (operator + version).
- [ ] Support sets of comparators.
- [ ] Support ranges, i.e. multiple comparator sets.
- [ ] Add to Readme.