### PR TITLE
Add workflows using `ifx` and `ifort` compilers to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,11 @@ jobs:
         env:
           compiler = ${{ matrix.toolchain.compiler }}
         run: |
-          if [[ $compiler == "gcc" ]]; then
+          if [[ "$compiler" == "gcc" ]]; then
             gfortran --version
-          elif [[ $compiler == "intel" ]]; then
+          elif [[ "$compiler" == "intel" ]]; then
             ifx --version
-          elif [[ $compiler == "intel-classic" ]]; then
+          elif [[ "$compiler" == "intel-classic" ]]; then
             ifort --version
           else
             echo "Unknown compiler"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,9 @@ jobs:
           compiler: ${{ matrix.toolchain.compiler }}
           version: ${{ matrix.toolchain.version }}
 
-      - name: Print Fortran compiler version
+      - run: ${{ env.FC }} --version
         env:
           FC: ${{ steps.setup-fortran.outputs.fc }}
-        run: ${{ env.FC }} --version
 
       - run: fpm test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,10 @@ jobs:
           compiler: ${{ matrix.toolchain.compiler }}
           version: ${{ matrix.toolchain.version }}
 
-      - run: ${{ env.FC }} --version
+      - name: Print Fortran compiler version
         env:
           FC: ${{ steps.setup-fortran.outputs.fc }}
+        run: ${{ env.FC }} --version
 
       - run: fpm test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,14 +25,26 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: awvwgk/setup-fortran@v1
-        if: matrix.os != 'ubuntu-latest'
+        if: matrix.os != 'ubuntu-latest' && matrix.toolchain.compiler == 'gcc'
         with:
           compiler: ${{ matrix.toolchain.compiler }}
           version: ${{ matrix.toolchain.version }}
 
       - name: Test fpm
+        env:
+          compiler = ${{ matrix.toolchain.compiler }}
         run: |
-          gfortran --version
+          if [[ $compiler == "gcc" ]]; then
+            gfortran --version
+          elif [[ $compiler == "intel" ]]; then
+            ifx --version
+          elif [[ $compiler == "intel-classic" ]]; then
+            ifort --version
+          else
+            echo "Unknown compiler"
+            exit 1
+          fi
+
           fpm test
 
   format:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         toolchain:
@@ -25,7 +26,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: awvwgk/setup-fortran@v1
-        # if: matrix.os != 'ubuntu-latest' && matrix.toolchain.compiler != 'gcc'
+        if: ${{ matrix.os != 'ubuntu-latest' && matrix.toolchain.compiler != 'gcc' }}
         with:
           compiler: ${{ matrix.toolchain.compiler }}
           version: ${{ matrix.toolchain.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,9 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         toolchain:
           - { compiler: gcc, version: 10 }
-          - { compiler: intel-classic, version: "2021.9" }
         include:
-          - os: ubuntu-latest
-            toolchain: { compiler: intel, version: "2023.1" }
-        exclude:
-          - os: windows-latest
-            toolchain: { compiler: intel-classic, version: "2021.9" }
+          - toolchain: { os: ubuntu-latest, compiler: intel, version: "2023.1" }
+          - toolchain: { os: ubuntu-latest, compiler: intel-classic, version: "2021.9" }
 
     steps:
       - uses: actions/checkout@v3
@@ -27,7 +23,6 @@ jobs:
 
       - uses: awvwgk/setup-fortran@v1
         id: setup-fortran
-        # if: ${{ matrix.os != 'ubuntu-latest' && matrix.toolchain.compiler != 'gcc' }}
         with:
           compiler: ${{ matrix.toolchain.compiler }}
           version: ${{ matrix.toolchain.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,10 @@ jobs:
         toolchain:
           - { compiler: gcc, version: 10 }
         include:
-          - toolchain: { os: ubuntu-latest, compiler: intel, version: "2023.1" }
-          - toolchain: { os: ubuntu-latest, compiler: intel-classic, version: "2021.9" }
+          - os: ubuntu-latest
+            toolchain: { compiler: intel, version: "2023.1" }
+          - os: ubuntu-latest
+            toolchain: { compiler: intel-classic, version: "2021.9" }
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,22 +30,20 @@ jobs:
           compiler: ${{ matrix.toolchain.compiler }}
           version: ${{ matrix.toolchain.version }}
 
-      - name: Test fpm
-        env:
-          compiler = ${{ matrix.toolchain.compiler }}
-        run: |
-          if [[ "$compiler" == "gcc" ]]; then
-            gfortran --version
-          elif [[ "$compiler" == "intel" ]]; then
-            ifx --version
-          elif [[ "$compiler" == "intel-classic" ]]; then
-            ifort --version
-          else
-            echo "Unknown compiler"
-            exit 1
-          fi
+      - name: gcc version
+        if: matrix.toolchain.compiler == 'gcc'
+        run: gfortran --version
 
-          fpm test
+      - name: intel version
+        if: matrix.toolchain.compiler == 'intel'
+        run: ifx --version
+
+      - name: intel-classic version
+        if: matrix.toolchain.compiler == 'intel-classic'
+        run: ifort --version
+
+      - name: Test fpm
+        run: fpm test
 
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         toolchain:
-          - { compiler: gcc, version: 11 }
+          - { compiler: gcc, version: 10 }
           - { compiler: intel-classic, version: "2021.9" }
         include:
           - os: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,15 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        toolchain:
+          - { compiler: gcc, version: 11 }
+          - { compiler: intel-classic, version: "2021.9" }
+        include:
+          - os: ubuntu-latest
+            toolchain: { compiler: intel, version: "2023.1" }
+        exclude:
+          - os: windows-latest
+            toolchain: { compiler: intel-classic, version: "2021.9" }
 
     steps:
       - uses: actions/checkout@v3
@@ -18,8 +27,8 @@ jobs:
       - uses: awvwgk/setup-fortran@v1
         if: matrix.os != 'ubuntu-latest'
         with:
-          compiler: gcc
-          version: 10
+          compiler: ${{ matrix.toolchain.compiler }}
+          version: ${{ matrix.toolchain.version }}
 
       - name: Test fpm
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: awvwgk/setup-fortran@v1
-        if: matrix.os != 'ubuntu-latest' && matrix.toolchain.compiler != 'gcc'
+        # if: matrix.os != 'ubuntu-latest' && matrix.toolchain.compiler != 'gcc'
         with:
           compiler: ${{ matrix.toolchain.compiler }}
           version: ${{ matrix.toolchain.version }}
@@ -42,8 +42,7 @@ jobs:
         if: matrix.toolchain.compiler == 'intel-classic'
         run: ifort --version
 
-      - name: Test fpm
-        run: fpm test
+      - run: fpm test
 
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: awvwgk/setup-fortran@v1
+        id: setup-fortran
         if: ${{ matrix.os != 'ubuntu-latest' && matrix.toolchain.compiler != 'gcc' }}
         with:
           compiler: ${{ matrix.toolchain.compiler }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         toolchain:
-          - { compiler: gcc, version: 10 }
+          - { compiler: gcc, version: 11 }
         include:
           - os: ubuntu-latest
             toolchain: { compiler: intel, version: "2023.1" }
@@ -19,9 +19,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: fortran-lang/setup-fpm@v5
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: awvwgk/setup-fortran@v1
         id: setup-fortran
@@ -32,6 +29,10 @@ jobs:
       - run: ${{ env.FC }} --version
         env:
           FC: ${{ steps.setup-fortran.outputs.fc }}
+
+      - uses: fortran-lang/setup-fpm@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - run: fpm test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: awvwgk/setup-fortran@v1
         id: setup-fortran
-        if: ${{ matrix.os != 'ubuntu-latest' && matrix.toolchain.compiler != 'gcc' }}
+        # if: ${{ matrix.os != 'ubuntu-latest' && matrix.toolchain.compiler != 'gcc' }}
         with:
           compiler: ${{ matrix.toolchain.compiler }}
           version: ${{ matrix.toolchain.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: awvwgk/setup-fortran@v1
-        if: matrix.os != 'ubuntu-latest' && matrix.toolchain.compiler == 'gcc'
+        if: matrix.os != 'ubuntu-latest' && matrix.toolchain.compiler != 'gcc'
         with:
           compiler: ${{ matrix.toolchain.compiler }}
           version: ${{ matrix.toolchain.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,17 +31,9 @@ jobs:
           compiler: ${{ matrix.toolchain.compiler }}
           version: ${{ matrix.toolchain.version }}
 
-      - name: gcc version
-        if: matrix.toolchain.compiler == 'gcc'
-        run: gfortran --version
-
-      - name: intel version
-        if: matrix.toolchain.compiler == 'intel'
-        run: ifx --version
-
-      - name: intel-classic version
-        if: matrix.toolchain.compiler == 'intel-classic'
-        run: ifort --version
+      - run: ${{ env.FC }} --version
+        env:
+          FC: ${{ steps.setup-fortran.outputs.fc }}
 
       - run: fpm test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         toolchain:
-          - { compiler: gcc, version: 11 }
+          - { compiler: gcc, version: 10 }
         include:
           - os: ubuntu-latest
             toolchain: { compiler: intel, version: "2023.1" }


### PR DESCRIPTION
Add CI workflows for:

- ubuntu-latest, intel, 2023.1
- ubuntu-latest, intel-classic, 2021.9

Further:

- Always fail fast.
- Always use `setup-fortran` action.
- Print compiler version using `setup-fortran` output.