### PR TITLE
Add `Makefile`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
 
   make:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         toolchain:
@@ -56,7 +57,7 @@ jobs:
         with:
           compiler: ${{ matrix.toolchain.compiler }}
           version: ${{ matrix.toolchain.version }}
-      - run: make test
+      - run: make test FC=${{ steps.setup-fortran.outputs.fc }}
 
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         toolchain:
-          - { compiler: gcc, version: 13 }
+          - { compiler: gcc, version: 10 }
         include:
           - os: ubuntu-latest
             toolchain: { compiler: intel, version: 2023.2 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,8 @@ jobs:
         with:
           compiler: ${{ matrix.toolchain.compiler }}
           version: ${{ matrix.toolchain.version }}
-      - run: ${{ steps.setup-fortran.outputs.fc }} /help
+      - run: ${{ steps.setup-fortran.outputs.fc }} /QV
+      - run: ${{ steps.setup-fortran.outputs.fc }} /what
       - uses: fortran-lang/setup-fpm@v5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           compiler: ${{ matrix.toolchain.compiler }}
           version: ${{ matrix.toolchain.version }}
-      - run: ${{ steps.setup-fortran.outputs.fc }} --version
+      - run: ${{ steps.setup-fortran.outputs.fc }} /version
       - uses: fortran-lang/setup-fpm@v5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -61,7 +61,7 @@ jobs:
         with:
           compiler: ${{ matrix.toolchain.compiler }}
           version: ${{ matrix.toolchain.version }}
-      - run: ${{ steps.setup-fortran.outputs.fc }} /version
+      - run: ${{ steps.setup-fortran.outputs.fc }} --version
       - run: make test FC=${{ steps.setup-fortran.outputs.fc }}
 
   format:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         toolchain:
-          - { compiler: gcc, version: 10 }
+          - { compiler: gcc, version: 13 }
         include:
           - os: ubuntu-latest
-            toolchain: { compiler: intel, version: "2023.2" }
+            toolchain: { compiler: intel, version: 2023.2 }
           - os: ubuntu-latest
-            toolchain: { compiler: intel-classic, version: "2021.10" }
+            toolchain: { compiler: intel-classic, version: 2021.10 }
+          - os: ubuntu-latest
+            toolchain: { compiler: nvidia-hpc, version: 23.11 }
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -37,7 +39,7 @@ jobs:
           - { compiler: gcc, version: 13 }
           - { compiler: intel, version: 2023.2 }
           - { compiler: intel-classic, version: 2021.10 }
-          - { compiler: nvidia-hpc, version: 23.9 }
+          - { compiler: nvidia-hpc, version: 23.11 }
         include:
           - os: macos-latest
             toolchain: { compiler: gcc, version: 13 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,7 @@ jobs:
             toolchain: { compiler: intel, version: "2023.2" }
           - os: ubuntu-latest
             toolchain: { compiler: intel-classic, version: "2021.10" }
-
     runs-on: ${{ matrix.os }}
-
     steps:
       - uses: actions/checkout@v4
       - uses: fortran-lang/setup-fortran@v1
@@ -45,9 +43,7 @@ jobs:
             toolchain: { compiler: gcc, version: 13 }
           - os: macos-13
             toolchain: { compiler: intel-classic, version: 2021.10 }
-
     runs-on: ${{ matrix.os }}
-
     steps:
       - uses: actions/checkout@v4
       - uses: fortran-lang/setup-fortran@v1
@@ -55,6 +51,7 @@ jobs:
         with:
           compiler: ${{ matrix.toolchain.compiler }}
           version: ${{ matrix.toolchain.version }}
+      - run: ${{ steps.setup-fortran.outputs.fc }} --version
       - run: make test FC=${{ steps.setup-fortran.outputs.fc }}
 
   format:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ on: push
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
-
     strategy:
       fail-fast: false
       matrix:
@@ -16,6 +14,8 @@ jobs:
             toolchain: { compiler: intel, version: "2023.2" }
           - os: ubuntu-latest
             toolchain: { compiler: intel-classic, version: "2021.10" }
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v4
@@ -35,12 +35,14 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - run: fpm test
-  
+
   make:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
+
+    runs-on: ${{ matrix.os }}
+
     steps:
       - uses: actions/checkout@v4
       - run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
       - name: Check formatting
         run: |
           pip install fprettify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,32 +19,43 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
       - uses: fortran-lang/setup-fortran@v1
         id: setup-fortran
         with:
           compiler: ${{ matrix.toolchain.compiler }}
           version: ${{ matrix.toolchain.version }}
-
       - run: ${{ env.FC }} --version
         env:
           FC: ${{ steps.setup-fortran.outputs.fc }}
-
       - uses: fortran-lang/setup-fpm@v5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-
       - run: fpm test
 
   make:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
+        toolchain:
+          - { compiler: gcc, version: 13 }
+          - { compiler: intel, version: 2023.2 }
+          - { compiler: intel-classic, version: 2021.10 }
+          - { compiler: nvidia-hpc, version: 23.9 }
+        include:
+          - os: macos-latest
+            toolchain: { compiler: gcc, version: 13 }
+          - os: macos-latest
+            toolchain: { compiler: intel-classic, version: 2021.10 }
 
     runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v4
+      - uses: fortran-lang/setup-fortran@v1
+        id: setup-fortran
+        with:
+          compiler: ${{ matrix.toolchain.compiler }}
+          version: ${{ matrix.toolchain.version }}
       - run: make test
 
   format:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,6 @@ jobs:
         with:
           compiler: ${{ matrix.toolchain.compiler }}
           version: ${{ matrix.toolchain.version }}
-      - name: Check Fortran compiler version
-        run: ${{ steps.setup-fortran.outputs.fc }} /QVersion
       - uses: fortran-lang/setup-fpm@v5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           compiler: ${{ matrix.toolchain.compiler }}
           version: ${{ matrix.toolchain.version }}
       - name: Check Fortran compiler version
-        run: ${{ steps.setup-fortran.outputs.fc }} /Qversion
+        run: ${{ steps.setup-fortran.outputs.fc }} /QVersion
       - uses: fortran-lang/setup-fpm@v5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
             toolchain: { compiler: intel-classic, version: 2021.10 }
           - os: ubuntu-latest
             toolchain: { compiler: nvidia-hpc, version: 23.11 }
+          - os: macos-13
+            toolchain: { compiler: intel-classic, version: 2021.10 }
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,13 @@ jobs:
         with:
           compiler: ${{ matrix.toolchain.compiler }}
           version: ${{ matrix.toolchain.version }}
-      - run: ${{ steps.setup-fortran.outputs.fc }} /QV
-      - run: ${{ steps.setup-fortran.outputs.fc }} /what
+      - name: Check Fortran compiler version
+        run: |
+          if [[ ${{ matrix.os }} == 'windows-latest' && ${{ matrix.toolchain.compiler }} == 'intel' ]]; then
+            ${{ steps.setup-fortran.outputs.fc }} /QV
+          else
+            ${{ steps.setup-fortran.outputs.fc }} --version
+          fi
       - uses: fortran-lang/setup-fpm@v5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,14 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         toolchain:
           - { compiler: gcc, version: 10 }
-        include:
-          - os: ubuntu-latest
+          - { compiler: intel, version: 2023.2 }
+          - { compiler: intel-classic, version: 2021.10 }
+        exclude:
+          - os: macos-latest
             toolchain: { compiler: intel, version: 2023.2 }
-          - os: ubuntu-latest
+          - os: macos-latest
             toolchain: { compiler: intel-classic, version: 2021.10 }
+        include:
           - os: ubuntu-latest
             toolchain: { compiler: nvidia-hpc, version: 23.11 }
           - os: macos-13

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,12 +33,7 @@ jobs:
           compiler: ${{ matrix.toolchain.compiler }}
           version: ${{ matrix.toolchain.version }}
       - name: Check Fortran compiler version
-        run:
-          if [ "${{ matrix.os }}" = "windows-latest" ] && [ "${{ matrix.toolchain.compiler }}" = "intel" ]; then
-            ${{ steps.setup-fortran.outputs.fc }} /QV
-          else
-            ${{ steps.setup-fortran.outputs.fc }} --version
-          fi
+        run: ${{ steps.setup-fortran.outputs.fc }} /Qversion
       - uses: fortran-lang/setup-fpm@v5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,17 +8,22 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         toolchain:
+          # - { compiler: gcc, version: 13 }
           - { compiler: gcc, version: 10 }
           - { compiler: intel, version: 2023.2 }
-          - { compiler: intel-classic, version: 2021.10 }
+          # - { compiler: intel-classic, version: 2021.10 }
         exclude:
           - os: macos-latest
             toolchain: { compiler: intel, version: 2023.2 }
-          - os: macos-latest
-            toolchain: { compiler: intel-classic, version: 2021.10 }
+          # - os: macos-latest
+          #   toolchain: { compiler: intel-classic, version: 2021.10 }
         include:
           - os: ubuntu-latest
             toolchain: { compiler: nvidia-hpc, version: 23.11 }
+          - os: ubuntu-latest
+            toolchain: { compiler: intel-classic, version: 2021.10 }
+          # - os: macos-13
+          #   toolchain: { compiler: intel-classic, version: 2021.10 }
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -27,7 +32,7 @@ jobs:
         with:
           compiler: ${{ matrix.toolchain.compiler }}
           version: ${{ matrix.toolchain.version }}
-      - run: ${{ steps.setup-fortran.outputs.fc }} --version
+      # - run: ${{ steps.setup-fortran.outputs.fc }} --version
       - uses: fortran-lang/setup-fpm@v5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on: push
 
 jobs:
-  test:
+  fpm-test:
     strategy:
       fail-fast: false
       matrix:
@@ -30,7 +30,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - run: fpm test
 
-  make:
+  make-test:
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           compiler: ${{ matrix.toolchain.compiler }}
           version: ${{ matrix.toolchain.version }}
-      # - run: ${{ steps.setup-fortran.outputs.fc }} --version
+      - run: ${{ steps.setup-fortran.outputs.fc }} --version
       - uses: fortran-lang/setup-fpm@v5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -61,7 +61,7 @@ jobs:
         with:
           compiler: ${{ matrix.toolchain.compiler }}
           version: ${{ matrix.toolchain.version }}
-      - run: ${{ steps.setup-fortran.outputs.fc }} --version
+      - run: ${{ steps.setup-fortran.outputs.fc }} /version
       - run: make test FC=${{ steps.setup-fortran.outputs.fc }}
 
   format:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
   
   make:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
       - run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           version: ${{ matrix.toolchain.version }}
       - name: Check Fortran compiler version
         run:
-          if [[ ${{ matrix.os }} == 'windows-latest' && ${{ matrix.toolchain.compiler }} == 'intel' ]]; then
+          if [ "${{ matrix.os }}" = "windows-latest" ] && [ "${{ matrix.toolchain.compiler }}" = "intel" ]; then
             ${{ steps.setup-fortran.outputs.fc }} /QV
           else
             ${{ steps.setup-fortran.outputs.fc }} --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           compiler: ${{ matrix.toolchain.compiler }}
           version: ${{ matrix.toolchain.version }}
-      - run: ${{ steps.setup-fortran.outputs.fc }} /version
+      - run: ${{ steps.setup-fortran.outputs.fc }} /help
       - uses: fortran-lang/setup-fpm@v5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,6 @@ jobs:
         include:
           - os: ubuntu-latest
             toolchain: { compiler: nvidia-hpc, version: 23.11 }
-          - os: macos-13
-            toolchain: { compiler: intel-classic, version: 2021.10 }
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,12 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - run: fpm test
+  
+  make:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: make test
 
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           compiler: ${{ matrix.toolchain.compiler }}
           version: ${{ matrix.toolchain.version }}
       - name: Check Fortran compiler version
-        run: |
+        run:
           if [[ ${{ matrix.os }} == 'windows-latest' && ${{ matrix.toolchain.compiler }} == 'intel' ]]; then
             ${{ steps.setup-fortran.outputs.fc }} /QV
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,7 @@ jobs:
         with:
           compiler: ${{ matrix.toolchain.compiler }}
           version: ${{ matrix.toolchain.version }}
-      - run: ${{ env.FC }} --version
-        env:
-          FC: ${{ steps.setup-fortran.outputs.fc }}
+      - run: ${{ steps.setup-fortran.outputs.fc }} --version
       - uses: fortran-lang/setup-fpm@v5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -45,7 +43,7 @@ jobs:
         include:
           - os: macos-latest
             toolchain: { compiler: gcc, version: 13 }
-          - os: macos-latest
+          - os: macos-13
             toolchain: { compiler: intel-classic, version: 2021.10 }
 
     runs-on: ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# build artifacts
+# Build artifacts
 build
 
 # Locally generated libraries

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# build artifacts
+build
+
+# Locally generated libraries
+*.a

--- a/Makefile
+++ b/Makefile
@@ -15,15 +15,15 @@ OBJ-DIR = $(BUILD-DIR)/obj
 TEST-DIR = $(BUILD-DIR)/test
 
 ifeq ($(FC),nvfortran)
-MOD-OUT-OPTION = -module $(MOD-DIR)
+	MOD-OUT-OPTION = -module $(MOD-DIR)
 else
-MOD-OUT-OPTION = -J$(MOD-DIR)
+	MOD-OUT-OPTION = -J$(MOD-DIR)
 endif
 
 ifeq ($(FC),nvfortran)
-MOD-IN-OPTION = -module $(MOD-DIR)
+	MOD-IN-OPTION = -module $(MOD-DIR)
 else
-MOD-IN-OPTION = -I$(MOD-DIR)
+	MOD-IN-OPTION = -I$(MOD-DIR)
 endif
 
 .PHONY: all test clean

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,11 @@ all: $(STATIC)
 
 $(STATIC): $(SRC)
 		mkdir -p $(MOD-DIR) $(OBJ-DIR)
-		$(FC) $(FFLAGS) -c $(SRC) -J$(MOD-DIR) -o $(OBJ-DIR)/$(FILENAME).o
+		ifeq ($(FC),nvfortran)
+			$(FC) $(FFLAGS) -c $(SRC) -module $(MOD-DIR) -o $(OBJ-DIR)/$(FILENAME).o
+		else
+			$(FC) $(FFLAGS) -c $(SRC) -J$(MOD-DIR) -o $(OBJ-DIR)/$(FILENAME).o
+		endif
 		$(AR) $(ARFLAGS) $(STATIC) $(OBJ-DIR)/$(FILENAME).o
 
 test: $(TEST-SRC) $(STATIC)

--- a/Makefile
+++ b/Makefile
@@ -15,15 +15,15 @@ OBJ-DIR = $(BUILD-DIR)/obj
 TEST-DIR = $(BUILD-DIR)/test
 
 ifeq ($(FC),nvfortran)
-	MOD-OUT-OPTION = -module $(MOD-DIR)
+	MOD-OUTPUT = -module $(MOD-DIR)
 else
-	MOD-OUT-OPTION = -J$(MOD-DIR)
+	MOD-OUTPUT = -J$(MOD-DIR)
 endif
 
 ifeq ($(FC),nvfortran)
-	MOD-IN-OPTION = -module $(MOD-DIR)
+	MOD-INPUT = -module $(MOD-DIR)
 else
-	MOD-IN-OPTION = -I$(MOD-DIR)
+	MOD-INPUT = -I$(MOD-DIR)
 endif
 
 .PHONY: all test clean
@@ -32,12 +32,12 @@ all: $(STATIC)
 
 $(STATIC): $(SRC)
 		mkdir -p $(MOD-DIR) $(OBJ-DIR)
-		$(FC) $(FFLAGS) -c $(SRC) $(MOD-OUT-OPTION) -o $(OBJ-DIR)/$(FILENAME).o
+		$(FC) $(FFLAGS) -c $(SRC) $(MOD-OUTPUT) -o $(OBJ-DIR)/$(FILENAME).o
 		$(AR) $(ARFLAGS) $(STATIC) $(OBJ-DIR)/$(FILENAME).o
 
 test: $(TEST-SRC) $(STATIC)
 		mkdir -p $(TEST-DIR)
-		$(FC) $(FFLAGS) $(TEST-SRC) $(MOD-IN-OPTION) -o $(TEST-DIR)/test.out $(STATIC)
+		$(FC) $(FFLAGS) $(TEST-SRC) $(MOD-INPUT) -o $(TEST-DIR)/test.out $(STATIC)
 		$(TEST-DIR)/test.out
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -14,22 +14,30 @@ MOD-DIR = $(BUILD-DIR)/mod
 OBJ-DIR = $(BUILD-DIR)/obj
 TEST-DIR = $(BUILD-DIR)/test
 
+ifeq ($(FC),nvfortran)
+MOD-OUT-OPTION = -module $(MOD-DIR)
+else
+MOD-OUT-OPTION = -J$(MOD-DIR)
+endif
+
+ifeq ($(FC),nvfortran)
+MOD-IN-OPTION = -module $(MOD-DIR)
+else
+MOD-IN-OPTION = -I$(MOD-DIR)
+endif
+
 .PHONY: all test clean
 
 all: $(STATIC)
 
 $(STATIC): $(SRC)
 		mkdir -p $(MOD-DIR) $(OBJ-DIR)
-		ifeq ($(FC),nvfortran)
-			$(FC) $(FFLAGS) -c $(SRC) -module $(MOD-DIR) -o $(OBJ-DIR)/$(FILENAME).o
-		else
-			$(FC) $(FFLAGS) -c $(SRC) -J$(MOD-DIR) -o $(OBJ-DIR)/$(FILENAME).o
-		endif
+		$(FC) $(FFLAGS) -c $(SRC) $(MOD-OUT-OPTION) -o $(OBJ-DIR)/$(FILENAME).o
 		$(AR) $(ARFLAGS) $(STATIC) $(OBJ-DIR)/$(FILENAME).o
 
 test: $(TEST-SRC) $(STATIC)
 		mkdir -p $(TEST-DIR)
-		$(FC) $(FFLAGS) $(TEST-SRC) -I$(MOD-DIR) -o $(TEST-DIR)/test.out $(STATIC)
+		$(FC) $(FFLAGS) $(TEST-SRC) $(MOD-IN-OPTION) -o $(TEST-DIR)/test.out $(STATIC)
 		$(TEST-DIR)/test.out
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+FC = gfortran
+FFLAGS = -O2
+AR = ar
+ARFLAGS = rcs
+
+NAME = version-f
+FILENAME = version_f
+SRC = src/$(FILENAME).f90
+TEST-SRC = test/test.f90
+STATIC = lib$(NAME).a
+
+BUILD-DIR = build/Makefile
+MOD-DIR = $(BUILD-DIR)/mod
+OBJ-DIR = $(BUILD-DIR)/obj
+TEST-DIR = $(BUILD-DIR)/test
+
+.PHONY: all test clean
+
+all: $(STATIC)
+
+$(STATIC): $(SRC)
+		mkdir -p $(MOD-DIR) $(OBJ-DIR)
+		$(FC) $(FFLAGS) -c $(SRC) -J$(MOD-DIR) -o $(OBJ-DIR)/$(FILENAME).o
+		$(AR) $(ARFLAGS) $(STATIC) $(OBJ-DIR)/$(FILENAME).o
+
+test: $(TEST-SRC) $(STATIC)
+		mkdir -p $(TEST-DIR)
+		$(FC) $(FFLAGS) $(TEST-SRC) -I$(MOD-DIR) -o $(TEST-DIR)/test.out $(STATIC)
+		$(TEST-DIR)/test.out
+
+clean:
+		rm -rf $(BUILD-DIR)
+		rm -f $(STATIC)

--- a/README.md
+++ b/README.md
@@ -38,13 +38,19 @@ Run `fpm build` to download the dependency.
 
 ### make
 
-You can also run the following command in the project's root directory to build the library:
+To build the library using the provided `Makefile`, navigate to the project's root directory and execute the following command if you are on a Unix-like system:
 
 ```bash
 make
 ```
 
-This will create a `libversion-f.a` file in the `lib` directory. You can link it to your project using the `-L` and `-l` flags.
+This will generate the static library `libversion-f.a` in the root directory. You can compile it alongside your project or link it using the `-L` and `-l` flags.
+
+If you wish to use a compiler other than `gfortran`, simply specify it by running:
+
+```bash
+make FC=<compiler>
+```
 
 ## Create versions
 
@@ -294,6 +300,12 @@ Run tests with:
 
 ```bash
 fpm test
+```
+
+Alternatively, you can use the provided `Makefile` if you are on a Unix-like system:
+
+```bash
+make test
 ```
 
 ## Formatting

--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ use version_f, only: version_t, error_t
 
 Run `fpm build` to download the dependency.
 
+### make
+
+You can also run the following command in the project's root directory to build the library:
+
+```bash
+make
+```
+
+This will create a `libversion-f.a` file in the `lib` directory. You can link it to your project using the `-L` and `-l` flags.
+
 ## Create versions
 
 Create versions using one of the following commands:

--- a/src/version_f.f90
+++ b/src/version_f.f90
@@ -810,7 +810,7 @@ contains
     type(version_range_t) :: version_range
     integer :: i
 
-    str = adjustl(trim(string))
+    str = trim(adjustl(string))
 
     if (len(str) == 0) then
       error = error_t('Do not compare empty expressions.'); return
@@ -820,6 +820,13 @@ contains
     if (allocated(error)) return
 
     do i = 1, size(version_range%comp_sets)
+      block
+        integer :: j
+        do j = 1, size(version_range%comp_sets(i)%comps)
+          print *, version_range%comp_sets(i)%comps(j)%op
+          print *, version_range%comp_sets(i)%comps(j)%version%to_string()
+        end do
+      end block
       call this%satisfies_comp_set(version_range%comp_sets(i), is_satisfied, error)
       if (is_satisfied .or. allocated(error)) return
     end do
@@ -936,7 +943,6 @@ contains
       else
         call comp%parse_comp_and_crop_str('', str, error)
       end if
-
       if (allocated(error)) return
       this%comps = [this%comps, comp]
       if (str == '') return

--- a/src/version_f.f90
+++ b/src/version_f.f90
@@ -872,6 +872,11 @@ contains
     if (allocated(error)) return
 
     this%comp_sets = [this%comp_sets, comp_set]
+
+    do i_sep= 1, size(comp_set%comps)
+      print *, comp_set%comps(i_sep)%op
+      print *, comp_set%comps(i_sep)%version%to_string()
+    end do
   end
 
   !> Parse a set of comparators that are separated by ` ` from a string. An

--- a/src/version_f.f90
+++ b/src/version_f.f90
@@ -675,11 +675,11 @@ contains
 
     do i = 1, min(size(lhs), size(rhs))
       if (lhs(i)%str == rhs(i)%str) cycle
-      if (is_numeric(lhs(i)%str) .and. is_numeric(rhs(i)%str)) then
+      if (lhs(i)%is_numeric() .and. rhs(i)%is_numeric()) then
         is_greater = s2i(lhs(i)%str) > s2i(rhs(i)%str); return
-      else if (is_numeric(lhs(i)%str)) then
+      else if (lhs(i)%is_numeric()) then
         is_greater = .false.; return
-      else if (is_numeric(rhs(i)%str)) then
+      else if (rhs(i)%is_numeric()) then
         is_greater = .true.; return
       end if
 

--- a/src/version_f.f90
+++ b/src/version_f.f90
@@ -922,26 +922,36 @@ contains
     end if
 
     allocate (this%comps(0))
+
     do
-      if (str(1:1) == '>') then
-        if (str(2:2) == '=') then
+      if (len(str) == 0) then
+        call comp%parse_comp_and_crop_str('', str, error)
+      else if (str(1:1) == '>') then
+        if (len(str) == 1) then
+          call comp%parse_comp_and_crop_str('>', str, error)
+        else if (str(2:2) == '=') then
           call comp%parse_comp_and_crop_str('>=', str, error)
         else
           call comp%parse_comp_and_crop_str('>', str, error)
         end if
       else if (str(1:1) == '<') then
-        if (str(2:2) == '=') then
+        if (len(str) == 1) then
+          call comp%parse_comp_and_crop_str('<', str, error)
+        else if (str(2:2) == '=') then
           call comp%parse_comp_and_crop_str('<=', str, error)
         else
           call comp%parse_comp_and_crop_str('<', str, error)
         end if
       else if (str(1:1) == '=') then
         call comp%parse_comp_and_crop_str('=', str, error)
+      else if (len(str) == 1) then
+        call comp%parse_comp_and_crop_str('', str, error)
       else if (str(1:2) == '!=') then
         call comp%parse_comp_and_crop_str('!=', str, error)
       else
         call comp%parse_comp_and_crop_str('', str, error)
       end if
+
       if (allocated(error)) return
       call this%extend_with(comp)
       if (str == '') return

--- a/src/version_f.f90
+++ b/src/version_f.f90
@@ -94,6 +94,7 @@ module version_f
   contains
     generic :: parse => parse_comp_set
     procedure, private :: parse_comp_set
+    generic :: extend_with => extend_comps
     procedure, private :: extend_comps
   end type
 
@@ -106,6 +107,7 @@ module version_f
   contains
     generic :: parse => parse_version_range
     procedure, private :: parse_version_range
+    generic :: extend_with => extend_comp_sets
     procedure, private :: extend_comp_sets
   end type
 
@@ -872,7 +874,7 @@ contains
       call comp_set%parse_comp_set(str(1:i_sep - 1), error)
       if (allocated(error)) return
 
-      call this%extend_comp_sets(comp_set)
+      call this%extend_with(comp_set)
       str = str(i_sep + 2:)
       i_sep = index(str, '||')
     end do
@@ -880,7 +882,7 @@ contains
     call comp_set%parse_comp_set(str, error)
     if (allocated(error)) return
 
-    call this%extend_comp_sets(comp_set)
+    call this%extend_with(comp_set)
   end
 
   !> Extend array of comparator sets within version range with another comparator.
@@ -941,7 +943,7 @@ contains
         call comp%parse_comp_and_crop_str('', str, error)
       end if
       if (allocated(error)) return
-      call this%extend_comps(comp)
+      call this%extend_with(comp)
       if (str == '') return
       str = trim(adjustl(str))
     end do

--- a/src/version_f.f90
+++ b/src/version_f.f90
@@ -927,7 +927,16 @@ contains
       end if
 
       if (allocated(error)) return
+      print *, 'after parse_comp_and_crop_str', comp%op, ' ', comp%version%to_string()
+      print *, size(this%comps)
       this%comps = [this%comps, comp]
+      print *, size(this%comps)
+      block
+        integer :: j
+        do j = 1, size(this%comps)
+          print *, this%comps(j)%op, ' ', this%comps(j)%version%to_string()
+        end do
+      end block
       if (str == '') return
       str = trim(adjustl(str))
     end do
@@ -950,10 +959,7 @@ contains
     type(error_t), allocatable, intent(out) :: error
 
     integer :: i
-print *, 'string ', str
-print *, op
     comp%op = op
-print *, comp%op
     str = trim(adjustl(str(len(op) + 1:)))
 
     i = operator_index(str)

--- a/src/version_f.f90
+++ b/src/version_f.f90
@@ -566,7 +566,7 @@ contains
     end if
   end
 
-  !> Check if a string is purely numerical.
+  !> Check if the string is purely numerical.
   elemental function is_numerical(str)
     character(*), intent(in) :: str
     logical :: is_numerical

--- a/src/version_f.f90
+++ b/src/version_f.f90
@@ -927,16 +927,16 @@ contains
       end if
 
       if (allocated(error)) return
-      print *, 'after parse_comp_and_crop_str', comp%op, ' ', comp%version%to_string()
-      print *, size(this%comps)
-      this%comps = [this%comps, comp]
-      print *, size(this%comps)
-      block
-        integer :: j
-        do j = 1, size(this%comps)
-          print *, this%comps(j)%op, ' ', this%comps(j)%version%to_string()
-        end do
-      end block
+
+      extend_array: block
+        type(comparator_t), allocatable :: tmp(:)
+        allocate (tmp(size(this%comps) + 1))
+        tmp(1:size(this%comps)) = this%comps
+        tmp(size(tmp)) = comp
+        deallocate (this%comps)
+        this%comps = tmp
+      end block extend_array
+
       if (str == '') return
       str = trim(adjustl(str))
     end do

--- a/src/version_f.f90
+++ b/src/version_f.f90
@@ -481,14 +481,21 @@ contains
   !> Convert an integer to a string.
   pure function int2s(num) result(str)
     integer, intent(in) :: num
-    character(:), allocatable :: str
+    character(len=:), allocatable :: str
 
-    if (num == 0) then
-      str = '0'
-    else
-      allocate (character(int(log10(real(num))) + 1) :: str)
-      write (str, '(I0)') num
-    end if
+    integer :: num_digits, tmp
+
+    tmp = num
+    num_digits = 0
+
+    do
+      num_digits = num_digits + 1
+      tmp = tmp/10
+      if (tmp == 0) exit
+    end do
+
+    allocate (character(num_digits) :: str)
+    write (str, '(I0)') num
   end
 
   !> Check for valid prerelease or build data and build identfiers from

--- a/src/version_f.f90
+++ b/src/version_f.f90
@@ -950,9 +950,10 @@ contains
     type(error_t), allocatable, intent(out) :: error
 
     integer :: i
-
+print *, 'string ', str
+print *, op
     comp%op = op
-
+print *, comp%op
     str = trim(adjustl(str(len(op) + 1:)))
 
     i = operator_index(str)

--- a/src/version_f.f90
+++ b/src/version_f.f90
@@ -872,11 +872,6 @@ contains
     if (allocated(error)) return
 
     this%comp_sets = [this%comp_sets, comp_set]
-
-    do i_sep= 1, size(comp_set%comps)
-      print *, comp_set%comps(i_sep)%op
-      print *, comp_set%comps(i_sep)%version%to_string()
-    end do
   end
 
   !> Parse a set of comparators that are separated by ` ` from a string. An

--- a/src/version_f.f90
+++ b/src/version_f.f90
@@ -561,17 +561,17 @@ contains
     end if
 
     ! Numerical identifiers must not start with 0.
-    if (is_numeric(str) .and. str(1:1) == '0') then
+    if (is_numerical(str) .and. str(1:1) == '0') then
       error = error_t("Numerical identifiers must not start with '0'."); return
     end if
   end
 
-  !> Check if a string is purely numeric.
-  elemental function is_numeric(str)
+  !> Check if a string is purely numerical.
+  elemental function is_numerical(str)
     character(*), intent(in) :: str
-    logical :: is_numeric
+    logical :: is_numerical
 
-    is_numeric = verify(str, '0123456789') == 0
+    is_numerical = verify(str, '0123456789') == 0
   end
 
   !> Check if string_t is purely numeric.

--- a/src/version_f.f90
+++ b/src/version_f.f90
@@ -485,20 +485,20 @@ contains
   !> Convert an integer to a string.
   pure function int2s(num) result(str)
     integer, intent(in) :: num
-    character(len=:), allocatable :: str
+    character(:), allocatable :: str
 
-    integer :: num_digits, tmp
+    integer :: digits, tmp
 
     tmp = num
-    num_digits = 0
+    digits = 0
 
     do
-      num_digits = num_digits + 1
+      digits = digits + 1
       tmp = tmp/10
       if (tmp == 0) exit
     end do
 
-    allocate (character(num_digits) :: str)
+    allocate (character(digits) :: str)
     write (str, '(I0)') num
   end
 

--- a/src/version_f.f90
+++ b/src/version_f.f90
@@ -820,13 +820,6 @@ contains
     if (allocated(error)) return
 
     do i = 1, size(version_range%comp_sets)
-      block
-        integer :: j
-        do j = 1, size(version_range%comp_sets(i)%comps)
-          print *, version_range%comp_sets(i)%comps(j)%op
-          print *, version_range%comp_sets(i)%comps(j)%version%to_string()
-        end do
-      end block
       call this%satisfies_comp_set(version_range%comp_sets(i), is_satisfied, error)
       if (is_satisfied .or. allocated(error)) return
     end do
@@ -905,39 +898,28 @@ contains
     character(:), allocatable :: str
     type(comparator_t) :: comp
 
-    str = string
+    str = trim(adjustl(string))
 
-    if (len_trim(str) == 0) then
+    if (len(str) == 0) then
       error = error_t('Comparator set cannot be empty.'); return
     end if
 
     allocate (this%comps(0))
-    print *, 'way before ', str
     do
-      str = trim(adjustl(str))
-
-      if (len(str) == 0) then
-        call comp%parse_comp_and_crop_str('', str, error)
-      else if (str(1:1) == '>') then
-        if (len(str) == 1) then
-          call comp%parse_comp_and_crop_str('>', str, error)
-        else if (str(2:2) == '=') then
+      if (str(1:1) == '>') then
+        if (str(2:2) == '=') then
           call comp%parse_comp_and_crop_str('>=', str, error)
         else
           call comp%parse_comp_and_crop_str('>', str, error)
         end if
       else if (str(1:1) == '<') then
-        if (len(str) == 1) then
-          call comp%parse_comp_and_crop_str('<', str, error)
-        else if (str(2:2) == '=') then
+        if (str(2:2) == '=') then
           call comp%parse_comp_and_crop_str('<=', str, error)
         else
           call comp%parse_comp_and_crop_str('<', str, error)
         end if
       else if (str(1:1) == '=') then
         call comp%parse_comp_and_crop_str('=', str, error)
-      else if (len(str) == 1) then
-        call comp%parse_comp_and_crop_str('', str, error)
       else if (str(1:2) == '!=') then
         call comp%parse_comp_and_crop_str('!=', str, error)
       else
@@ -947,6 +929,7 @@ contains
       if (allocated(error)) return
       this%comps = [this%comps, comp]
       if (str == '') return
+      str = trim(adjustl(str))
     end do
   end
 
@@ -970,13 +953,9 @@ contains
 
     comp%op = op
 
-    print *, op
-    print *, str, 'before'
     str = trim(adjustl(str(len(op) + 1:)))
 
-    print *, str, 'after'
     i = operator_index(str)
-    print *, 'index ', i
     if (i == 0) then
       call comp%version%parse(str, error)
       str = ''

--- a/src/version_f.f90
+++ b/src/version_f.f90
@@ -930,11 +930,13 @@ contains
 
       extend_array: block
         type(comparator_t), allocatable :: tmp(:)
+        integer :: i
         allocate (tmp(size(this%comps) + 1))
-        tmp(1:size(this%comps)) = this%comps
+        do i = 1, size(this%comps)
+          tmp(i) = this%comps(i)
+        end do
         tmp(size(tmp)) = comp
-        deallocate (this%comps)
-        this%comps = tmp
+        call move_alloc(tmp, this%comps)
       end block extend_array
 
       if (str == '') return

--- a/src/version_f.f90
+++ b/src/version_f.f90
@@ -8,6 +8,19 @@ module version_f
   public :: version_t, string_t, error_t, is_version, version_range_t, &
             comparator_set_t, comparator_t, operator_index
 
+  type :: string_t
+    character(:), allocatable :: str
+  contains
+    generic :: num => string_t_2i
+    procedure, private :: string_t_2i
+    generic :: is_numeric => string_t_is_numeric
+    procedure, private :: string_t_is_numeric
+  end type
+
+  interface string_t
+    module procedure :: create_string_t
+  end interface
+
   !> Contains all version information.
   type :: version_t
     !> The major version number. Incremented when breaking changes are made.
@@ -57,43 +70,12 @@ module version_f
     module procedure create, parse
   end interface
 
-  type :: string_t
-    character(:), allocatable :: str
-  contains
-    generic :: num => string_t_2i
-    procedure, private :: string_t_2i
-    generic :: is_numeric => string_t_is_numeric
-    procedure, private :: string_t_is_numeric
-  end type
-
-  interface string_t
-    module procedure :: create_string_t
-  end interface
-
   type :: error_t
     character(:), allocatable :: msg
   end type
 
   interface error_t
     module procedure :: create_error_t
-  end interface
-
-  type :: version_range_t
-    type(comparator_set_t), allocatable :: comp_sets(:)
-  contains
-    generic :: parse => parse_version_range
-    procedure :: parse_version_range
-  end type
-
-  type :: comparator_set_t
-    type(comparator_t), allocatable :: comps(:)
-  contains
-    generic :: parse => parse_comp_set
-    procedure, private :: parse_comp_set
-  end type
-
-  interface comparator_set_t
-    module procedure :: create_comp_set
   end interface
 
   type :: comparator_t
@@ -106,6 +88,24 @@ module version_f
   interface comparator_t
     module procedure :: create_comp
   end interface
+
+  type :: comparator_set_t
+    type(comparator_t), allocatable :: comps(:)
+  contains
+    generic :: parse => parse_comp_set
+    procedure, private :: parse_comp_set
+  end type
+
+  interface comparator_set_t
+    module procedure :: create_comp_set
+  end interface
+
+  type :: version_range_t
+    type(comparator_set_t), allocatable :: comp_sets(:)
+  contains
+    generic :: parse => parse_version_range
+    procedure :: parse_version_range
+  end type
 
 contains
 

--- a/src/version_f.f90
+++ b/src/version_f.f90
@@ -889,7 +889,7 @@ contains
   end
 
   !> Parse a set of comparators that are separated by ` ` from a string. An
-  !> example of a set of comparators is `>=1.2.3 <2.0.0`.
+  !> example of a set of two comparators is `>=1.2.3 <2.0.0`.
   subroutine parse_comp_set(this, string, error)
 
     !> Set of comparators to be determined. They are separated by ` ` if there
@@ -912,7 +912,7 @@ contains
     end if
 
     allocate (this%comps(0))
-
+    print *, 'way before ', str
     do
       str = trim(adjustl(str))
 
@@ -943,6 +943,7 @@ contains
       else
         call comp%parse_comp_and_crop_str('', str, error)
       end if
+
       if (allocated(error)) return
       this%comps = [this%comps, comp]
       if (str == '') return
@@ -969,9 +970,13 @@ contains
 
     comp%op = op
 
+    print *, op
+    print *, str, 'before'
     str = trim(adjustl(str(len(op) + 1:)))
 
+    print *, str, 'after'
     i = operator_index(str)
+    print *, 'index ', i
     if (i == 0) then
       call comp%version%parse(str, error)
       str = ''

--- a/test/test.f90
+++ b/test/test.f90
@@ -1459,6 +1459,14 @@ program test
   if (comp_set%comps(2)%version /= version_t(2, 1, 0)) call fail('parse-comp-set-8: Version does not match.')
   if (allocated(e)) call fail('parse-comp-set-8 should not fail.')
 
+  call comp_set%parse('  >= 1.0.1 <=  2.1.0 ', e)
+  if (size(comp_set%comps) /= 2) call fail("parse-comp-set-9: Wrong number of comparators.")
+  if (comp_set%comps(1)%op /= '>=') call fail("parse-comp-set-9: Wrong operator parsed.")
+  if (comp_set%comps(1)%version /= version_t(1, 0, 1)) call fail('parse-comp-set-9: Version does not match.')
+  if (comp_set%comps(2)%op /= '<=') call fail("parse-comp-set-9: Wrong operator parsed.")
+  if (comp_set%comps(2)%version /= version_t(2, 1, 0)) call fail('parse-comp-set-9: Version does not match.')
+  if (allocated(e)) call fail('parse-comp-set-9 should not fail.')
+
 !##############################parse_version_range#############################!
 
   call range%parse('', e)

--- a/test/test.f90
+++ b/test/test.f90
@@ -1452,11 +1452,6 @@ program test
   if (allocated(e)) call fail('parse-comp-set-7 should not fail.')
 
   call comp_set%parse('  > 1.0.1 <  2.1.0 ', e)
-  print *, size(comp_set%comps)
-  print *, comp_set%comps(1)%op
-  print *, comp_set%comps(1)%version%to_string()
-  print *, comp_set%comps(2)%op
-  print *, comp_set%comps(2)%version%to_string()
   if (size(comp_set%comps) /= 2) call fail("parse-comp-set-8: Wrong number of comparators.")
   if (comp_set%comps(1)%op /= '>') call fail("parse-comp-set-8: Wrong operator parsed.")
   if (comp_set%comps(1)%version /= version_t(1, 0, 1)) call fail('parse-comp-set-8: Version does not match.')

--- a/test/test.f90
+++ b/test/test.f90
@@ -1079,6 +1079,7 @@ program test
 
   call v1%try_satisfy('  > 1.0.1 <  2.1.0 ', is_satisfied, e)
   if (is_satisfied) call fail('satisfy-36 should not satisfy.')
+  if (allocated(e)) print *, e%msg
   if (allocated(e)) call fail('satisfy-36 should not fail.')
 
   call v1%try_satisfy('>0.0.1 <=0.1.0', is_satisfied, e)

--- a/test/test.f90
+++ b/test/test.f90
@@ -1451,6 +1451,19 @@ program test
   if (comp_set%comps(3)%version /= version_t(2)) call fail('parse-comp-set-7: Version does not match.')
   if (allocated(e)) call fail('parse-comp-set-7 should not fail.')
 
+  call comp_set%parse('  > 1.0.1 <  2.1.0 ', e)
+  print *, size(comp_set%comps)
+  print *, comp_set%comps(1)%op
+  print *, comp_set%comps(1)%version%to_string()
+  print *, comp_set%comps(2)%op
+  print *, comp_set%comps(2)%version%to_string()
+  if (size(comp_set%comps) /= 2) call fail("parse-comp-set-8: Wrong number of comparators.")
+  if (comp_set%comps(1)%op /= '>') call fail("parse-comp-set-8: Wrong operator parsed.")
+  if (comp_set%comps(1)%version /= version_t(1, 0, 1)) call fail('parse-comp-set-8: Version does not match.')
+  if (comp_set%comps(2)%op /= '<') call fail("parse-comp-set-8: Wrong operator parsed.")
+  if (comp_set%comps(2)%version /= version_t(2, 1, 0)) call fail('parse-comp-set-8: Version does not match.')
+  if (allocated(e)) call fail('parse-comp-set-8 should not fail.')
+
 !##############################parse_version_range#############################!
 
   call range%parse('', e)

--- a/test/test.f90
+++ b/test/test.f90
@@ -1079,7 +1079,6 @@ program test
 
   call v1%try_satisfy('  > 1.0.1 <  2.1.0 ', is_satisfied, e)
   if (is_satisfied) call fail('satisfy-36 should not satisfy.')
-  if (allocated(e)) print *, e%msg
   if (allocated(e)) call fail('satisfy-36 should not fail.')
 
   call v1%try_satisfy('>0.0.1 <=0.1.0', is_satisfied, e)


### PR DESCRIPTION
Allow builds using `make`.

- [x] Add `Makefile`.
- [x] Add `.gitignore`.
- [x] Run `make test` in CI.
- [x] Add new combinations of compilers and operating systems.
- [x] Make compatible with `nvfortran`.
- [x] Fix CI issues.
- [x] Explicitly set python version in CI.
- [x] Add documentation.