### PR TITLE
Add examples to `Makefile` and use automatic keywords

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,15 +18,15 @@ OBJDIR = $(BUILDDIR)/obj
 TESTDIR = $(BUILDDIR)/test
 
 ifeq ($(FC),nvfortran)
-	MOD-OUTPUT = -module $(MODDIR)
+	MODOUT = -module $(MODDIR)
 else
-	MOD-OUTPUT = -J$(MODDIR)
+	MODOUT = -J$(MODDIR)
 endif
 
 ifeq ($(FC),nvfortran)
-	MOD-INPUT = -module $(MODDIR)
+	MODIN = -module $(MODDIR)
 else
-	MOD-INPUT = -I$(MODDIR)
+	MODIN = -I$(MODDIR)
 endif
 
 .PHONY: all test clean
@@ -35,12 +35,12 @@ all: $(STATIC)
 
 $(STATIC): $(SRC)
 		mkdir -p $(MODDIR) $(OBJDIR)
-		$(FC) $(FFLAGS) -c $(SRC) $(MODOUTPUT) -o $(OBJDIR)/$(FILENAME).o
+		$(FC) $(FFLAGS) -c $(SRC) $(MODOUT) -o $(OBJDIR)/$(FILENAME).o
 		$(AR) $(ARFLAGS) $(STATIC) $(OBJDIR)/$(FILENAME).o
 
 test: $(TESTSRC) $(STATIC)
 		mkdir -p $(TESTDIR)
-		$(FC) $(FFLAGS) $(TESTSRC) $(MODINPUT) -o $(TESTDIR)/test.out $(STATIC)
+		$(FC) $(FFLAGS) $(TESTSRC) $(MODIN) -o $(TESTDIR)/test.out $(STATIC)
 		$(TESTDIR)/test.out
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -12,15 +12,18 @@ STATIC = lib$(NAME).a
 
 SRCDIR = src
 TESTDIR = test
+EXMPLDIR = example
 BUILDDIR = build/Makefile
 MODDIR = $(BUILDDIR)/mod
 OBJDIR = $(BUILDDIR)/obj
 EXEDIR = $(BUILDDIR)/exe
 
-SRCS := $(wildcard $(SRCDIR)/*.f90)
-TESTSRCS := $(wildcard $(TESTDIR)/*.f90)
-OBJS := $(patsubst $(SRCDIR)/%.f90,$(OBJDIR)/%.o,$(SRCS))
-TESTOBJS := $(patsubst $(TESTDIR)/%.f90,$(EXEDIR)/%.out,$(TESTSRCS))
+SRCS = $(wildcard $(SRCDIR)/*.f90)
+TESTSRCS = $(wildcard $(TESTDIR)/*.f90)
+EXMPLSRCS = $(wildcard $(EXMPLDIR)/*.f90)
+OBJS = $(patsubst $(SRCDIR)/%.f90,$(OBJDIR)/%.o,$(SRCS))
+TESTEXES = $(patsubst $(TESTDIR)/%.f90,$(EXEDIR)/%.out,$(TESTSRCS))
+EXMPLEXES = $(patsubst $(EXMPLDIR)/%.f90,$(EXEDIR)/%.out,$(EXMPLSRCS))
 
 ifeq ($(FC),nvfortran)
 	MODOUT = -module $(MODDIR)
@@ -47,8 +50,12 @@ $(EXEDIR)/%.out: $(TESTDIR)/%.f90 $(STATIC)
 		mkdir -p $(EXEDIR)
 		$(FC) $(FFLAGS) $< $(MODIN) -o $@ $(STATIC)
 
-test: $(TESTOBJS)
-		$(TESTOBJS)
+$(EXEDIR)/%.out: $(EXMPLDIR)/%.f90 $(STATIC)
+		mkdir -p $(EXEDIR)
+		$(FC) $(FFLAGS) $< $(MODIN) -o $@ $(STATIC)
+
+test: $(TESTEXES) $(EXMPLEXES)
+		@for f in $(TESTEXES) $(EXMPLEXES); do $$f; done
 
 clean:
 		rm -rf $(BUILDDIR)

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+.POSIX:
+.SUFFIXES:
+
 FC = gfortran
 FFLAGS = -O2
 AR = ar

--- a/Makefile
+++ b/Makefile
@@ -9,24 +9,24 @@ ARFLAGS = rcs
 NAME = version-f
 FILENAME = version_f
 SRC = src/$(FILENAME).f90
-TEST-SRC = test/version_f_test.f90
+TESTSRC = test/version_f_test.f90
 STATIC = lib$(NAME).a
 
-BUILD-DIR = build/Makefile
-MOD-DIR = $(BUILD-DIR)/mod
-OBJ-DIR = $(BUILD-DIR)/obj
-TEST-DIR = $(BUILD-DIR)/test
+BUILDDIR = build/Makefile
+MODDIR = $(BUILDDIR)/mod
+OBJDIR = $(BUILDDIR)/obj
+TESTDIR = $(BUILDDIR)/test
 
 ifeq ($(FC),nvfortran)
-	MOD-OUTPUT = -module $(MOD-DIR)
+	MOD-OUTPUT = -module $(MODDIR)
 else
-	MOD-OUTPUT = -J$(MOD-DIR)
+	MOD-OUTPUT = -J$(MODDIR)
 endif
 
 ifeq ($(FC),nvfortran)
-	MOD-INPUT = -module $(MOD-DIR)
+	MOD-INPUT = -module $(MODDIR)
 else
-	MOD-INPUT = -I$(MOD-DIR)
+	MOD-INPUT = -I$(MODDIR)
 endif
 
 .PHONY: all test clean
@@ -34,15 +34,15 @@ endif
 all: $(STATIC)
 
 $(STATIC): $(SRC)
-		mkdir -p $(MOD-DIR) $(OBJ-DIR)
-		$(FC) $(FFLAGS) -c $(SRC) $(MOD-OUTPUT) -o $(OBJ-DIR)/$(FILENAME).o
-		$(AR) $(ARFLAGS) $(STATIC) $(OBJ-DIR)/$(FILENAME).o
+		mkdir -p $(MODDIR) $(OBJDIR)
+		$(FC) $(FFLAGS) -c $(SRC) $(MODOUTPUT) -o $(OBJDIR)/$(FILENAME).o
+		$(AR) $(ARFLAGS) $(STATIC) $(OBJDIR)/$(FILENAME).o
 
-test: $(TEST-SRC) $(STATIC)
-		mkdir -p $(TEST-DIR)
-		$(FC) $(FFLAGS) $(TEST-SRC) $(MOD-INPUT) -o $(TEST-DIR)/test.out $(STATIC)
-		$(TEST-DIR)/test.out
+test: $(TESTSRC) $(STATIC)
+		mkdir -p $(TESTDIR)
+		$(FC) $(FFLAGS) $(TESTSRC) $(MODINPUT) -o $(TESTDIR)/test.out $(STATIC)
+		$(TESTDIR)/test.out
 
 clean:
-		rm -rf $(BUILD-DIR)
+		rm -rf $(BUILDDIR)
 		rm -f $(STATIC)


### PR DESCRIPTION
- [x] Run examples in `Makefile`'s `test` rule.
- [x] Use automatic variables in `Makefile`.
- [x] Use special targets.