### PR TITLE
Add support for shared libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ build
 
 # Locally generated libraries
 *.a
+*.so
+*.dylib

--- a/Makefile
+++ b/Makefile
@@ -71,11 +71,11 @@ $(EXEDIRSTATIC)/%.out: $(EXMPLDIR)/%.f90 $(STATIC)
 
 $(EXEDIRSHARED)/%.out: $(TESTDIR)/%.f90 $(SHARED)
 	mkdir -p $(EXEDIRSHARED)
-	$(FC) $(FFLAGS) -L. $(MODIN) -o $@ $< $(SHARED)
+	$(FC) $(FFLAGS) -L../../../.. $(MODIN) -o $@ $< $(SHARED)
 
 $(EXEDIRSHARED)/%.out: $(EXMPLDIR)/%.f90 $(SHARED)
 	mkdir -p $(EXEDIRSHARED)
-	$(FC) $(FFLAGS) -L. $(MODIN) -o $@ $< $(SHARED)
+	$(FC) $(FFLAGS) -L../../../.. $(MODIN) -o $@ $< $(SHARED)
 
 test: $(TESTEXESSTATIC) $(TESTEXESSHARED) $(EXMPLEXESSTATIC) $(EXMPLEXESSHARED)
 	@for f in $^; do $$f; done

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ STATIC := lib$(NAME).a
 
 ifeq ($(shell uname), Linux)
     SHARED := lib$(NAME).so
+	LDFLAGS := -rpath=.
 else ifeq ($(shell uname), Darwin)
     SHARED := lib$(NAME).dylib
 endif
@@ -71,11 +72,11 @@ $(EXEDIRSTATIC)/%.out: $(EXMPLDIR)/%.f90 $(STATIC)
 
 $(EXEDIRSHARED)/%.out: $(TESTDIR)/%.f90 $(SHARED)
 	mkdir -p $(EXEDIRSHARED)
-	$(FC) $(FFLAGS) $(MODIN) -o $@ $< $(SHARED) -Wl,-rpath=.
+	$(FC) $(FFLAGS) $(MODIN) -o $@ $< $(SHARED) $(LDFLAGS)
 
 $(EXEDIRSHARED)/%.out: $(EXMPLDIR)/%.f90 $(SHARED)
 	mkdir -p $(EXEDIRSHARED)
-	$(FC) $(FFLAGS) $(MODIN) -o $@ $< $(SHARED) -Wl,-rpath=.
+	$(FC) $(FFLAGS) $(MODIN) -o $@ $< $(SHARED)	$(LDFLAGS)
 
 test: $(TESTEXESSTATIC) $(TESTEXESSHARED) $(EXMPLEXESSTATIC) $(EXMPLEXESSHARED)
 	@for f in $^; do $$f; done

--- a/Makefile
+++ b/Makefile
@@ -71,13 +71,14 @@ $(EXEDIRSTATIC)/%.out: $(EXMPLDIR)/%.f90 $(STATIC)
 
 $(EXEDIRSHARED)/%.out: $(TESTDIR)/%.f90 $(SHARED)
 	mkdir -p $(EXEDIRSHARED)
-	$(FC) $(FFLAGS) -L../../../.. $(MODIN) -o $@ $< $(SHARED)
+	$(FC) $(FFLAGS) $(MODIN) -o $@ $< $(SHARED)
 
 $(EXEDIRSHARED)/%.out: $(EXMPLDIR)/%.f90 $(SHARED)
 	mkdir -p $(EXEDIRSHARED)
-	$(FC) $(FFLAGS) -L../../../.. $(MODIN) -o $@ $< $(SHARED)
+	$(FC) $(FFLAGS) $(MODIN) -o $@ $< $(SHARED)
 
 test: $(TESTEXESSTATIC) $(TESTEXESSHARED) $(EXMPLEXESSTATIC) $(EXMPLEXESSHARED)
+	@ls
 	@for f in $^; do $$f; done
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -25,16 +25,16 @@ OBJDIR := $(BUILDDIR)/obj
 EXEDIRSTATIC := $(BUILDDIR)/exe/static
 EXEDIRSHARED := $(BUILDDIR)/exe/shared
 
-ifeq ($(FC),nvfortran)
-	MODOUT := -module $(MODDIR)
-else
+ifeq ($(FC),gfortran)
 	MODOUT := -J$(MODDIR)
+else
+	MODOUT := -module $(MODDIR)
 endif
 
-ifeq ($(FC),nvfortran)
-	MODIN := -module $(MODDIR)
-else
+ifeq ($(FC),gfortran)
 	MODIN := -I$(MODDIR)
+else
+	MODIN := -module $(MODDIR)
 endif
 
 SRCS := $(wildcard $(SRCDIR)/*.f90)

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,12 @@ MODDIR := $(BUILDDIR)/mod
 OBJDIR := $(BUILDDIR)/obj
 EXEDIR := $(BUILDDIR)/exe
 
+SRCS := $(wildcard $(SRCDIR)/*.f90)
+OBJS := $(patsubst $(SRCDIR)/%.f90,$(OBJDIR)/%.o,$(SRCS))
+EXESRCS := $(foreach dir,$(TESTDIR) $(EXMPLDIR),$(wildcard $(dir)/*.f90))
+EXESSTATIC := $(patsubst %.f90,$(EXEDIR)/%_static.out,$(notdir $(EXESRCS)))
+EXESSHARED := $(patsubst %.f90,$(EXEDIR)/%_shared.out,$(notdir $(EXESRCS)))
+
 ifeq ($(FC),gfortran)
 	MODIN := -I$(MODDIR)
 	MODOUT := -J$(MODDIR)
@@ -32,12 +38,6 @@ else
 	MODIN := -module $(MODDIR)
 	MODOUT := MODIN
 endif
-
-SRCS := $(wildcard $(SRCDIR)/*.f90)
-OBJS := $(patsubst $(SRCDIR)/%.f90,$(OBJDIR)/%.o,$(SRCS))
-EXESRCS := $(foreach dir,$(TESTDIR) $(EXMPLDIR),$(wildcard $(dir)/*.f90))
-EXESSTATIC := $(patsubst %.f90,$(EXEDIR)/%_static.out,$(notdir $(EXESRCS)))
-EXESSHARED := $(patsubst %.f90,$(EXEDIR)/%_shared.out,$(notdir $(EXESRCS)))
 
 all: $(STATIC) $(SHARED)
 static: $(STATIC)

--- a/Makefile
+++ b/Makefile
@@ -71,14 +71,13 @@ $(EXEDIRSTATIC)/%.out: $(EXMPLDIR)/%.f90 $(STATIC)
 
 $(EXEDIRSHARED)/%.out: $(TESTDIR)/%.f90 $(SHARED)
 	mkdir -p $(EXEDIRSHARED)
-	$(FC) $(FFLAGS) $(MODIN) -o $@ $< $(SHARED)
+	$(FC) $(FFLAGS) $(MODIN) -o $@ $< $(SHARED) -Wl,-rpath=../../../..
 
 $(EXEDIRSHARED)/%.out: $(EXMPLDIR)/%.f90 $(SHARED)
 	mkdir -p $(EXEDIRSHARED)
-	$(FC) $(FFLAGS) $(MODIN) -o $@ $< $(SHARED)
+	$(FC) $(FFLAGS) $(MODIN) -o $@ $< $(SHARED) -Wl,-rpath=../../../..
 
 test: $(TESTEXESSTATIC) $(TESTEXESSHARED) $(EXMPLEXESSTATIC) $(EXMPLEXESSHARED)
-	@ls
 	@for f in $^; do $$f; done
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ STATIC := lib$(NAME).a
 
 ifeq ($(shell uname), Linux)
     SHARED := lib$(NAME).so
-	LDFLAGS := -rpath=.
+	LDFLAGS := -Wl,-rpath=.
 else ifeq ($(shell uname), Darwin)
     SHARED := lib$(NAME).dylib
 endif

--- a/Makefile
+++ b/Makefile
@@ -27,15 +27,11 @@ EXEDIRSTATIC := $(BUILDDIR)/exe/static
 EXEDIRSHARED := $(BUILDDIR)/exe/shared
 
 ifeq ($(FC),gfortran)
+	MODIN := -I$(MODDIR)
 	MODOUT := -J$(MODDIR)
 else
-	MODOUT := -module $(MODDIR)
-endif
-
-ifeq ($(FC),gfortran)
-	MODIN := -I$(MODDIR)
-else
 	MODIN := -module $(MODDIR)
+	MODOUT := MODIN
 endif
 
 SRCS := $(wildcard $(SRCDIR)/*.f90)

--- a/Makefile
+++ b/Makefile
@@ -1,62 +1,86 @@
 .POSIX:
 .SUFFIXES:
-.PHONY: all test clean
+.PHONY: all static shared test clean
 
-FC = gfortran
-FFLAGS = -O2
-AR = ar
-ARFLAGS = rcs
+FC := gfortran
+FFLAGS := -O2
+AR := ar
+ARFLAGS := rcs
 
-NAME = version-f
-STATIC = lib$(NAME).a
+NAME := version-f
+STATIC := lib$(NAME).a
 
-SRCDIR = src
-TESTDIR = test
-EXMPLDIR = example
-BUILDDIR = build/Makefile
-MODDIR = $(BUILDDIR)/mod
-OBJDIR = $(BUILDDIR)/obj
-EXEDIR = $(BUILDDIR)/exe
+ifeq ($(shell uname), Linux)
+    SHARED := lib$(NAME).so
+else ifeq ($(shell uname), Darwin)
+    SHARED := lib$(NAME).dylib
+endif
 
-SRCS = $(wildcard $(SRCDIR)/*.f90)
-TESTSRCS = $(wildcard $(TESTDIR)/*.f90)
-EXMPLSRCS = $(wildcard $(EXMPLDIR)/*.f90)
-OBJS = $(patsubst $(SRCDIR)/%.f90,$(OBJDIR)/%.o,$(SRCS))
-TESTEXES = $(patsubst $(TESTDIR)/%.f90,$(EXEDIR)/%.out,$(TESTSRCS))
-EXMPLEXES = $(patsubst $(EXMPLDIR)/%.f90,$(EXEDIR)/%.out,$(EXMPLSRCS))
+SRCDIR := src
+TESTDIR := test
+EXMPLDIR := example
+BUILDDIR := build/Makefile
+MODDIR := $(BUILDDIR)/mod
+OBJDIR := $(BUILDDIR)/obj
+EXEDIRSTATIC := $(BUILDDIR)/exe/static
+EXEDIRSHARED := $(BUILDDIR)/exe/shared
 
 ifeq ($(FC),nvfortran)
-	MODOUT = -module $(MODDIR)
+	MODOUT := -module $(MODDIR)
 else
-	MODOUT = -J$(MODDIR)
+	MODOUT := -J$(MODDIR)
 endif
 
 ifeq ($(FC),nvfortran)
-	MODIN = -module $(MODDIR)
+	MODIN := -module $(MODDIR)
 else
-	MODIN = -I$(MODDIR)
+	MODIN := -I$(MODDIR)
 endif
 
-all: $(STATIC)
+SRCS := $(wildcard $(SRCDIR)/*.f90)
+TESTSRCS := $(wildcard $(TESTDIR)/*.f90)
+EXMPLSRCS := $(wildcard $(EXMPLDIR)/*.f90)
+OBJS := $(patsubst $(SRCDIR)/%.f90,$(OBJDIR)/%.o,$(SRCS))
+TESTEXESSTATIC := $(patsubst $(TESTDIR)/%.f90,$(EXEDIRSTATIC)/%.out,$(TESTSRCS))
+TESTEXESSHARED := $(patsubst $(TESTDIR)/%.f90,$(EXEDIRSHARED)/%.out,$(TESTSRCS))
+EXMPLEXESSTATIC := $(patsubst $(EXMPLDIR)/%.f90,$(EXEDIRSTATIC)/%.out,$(EXMPLSRCS))
+EXMPLEXESSHARED := $(patsubst $(EXMPLDIR)/%.f90,$(EXEDIRSHARED)/%.out,$(EXMPLSRCS))
+
+all: $(STATIC) $(SHARED)
+static: $(STATIC)
+shared: $(SHARED)
 
 $(OBJDIR)/%.o: $(SRCDIR)/%.f90
-		mkdir -p $(MODDIR) $(OBJDIR)
-		$(FC) $(FFLAGS) $(MODOUT) -c $< -o $@
+	mkdir -p $(MODDIR) $(OBJDIR)
+	$(FC) $(FFLAGS) $(MODOUT) -c $< -o $@
 
 $(STATIC): $(OBJS)
-		$(AR) $(ARFLAGS) $@ $(OBJS)
+	$(AR) $(ARFLAGS) $@ $(OBJS)
 
-$(EXEDIR)/%.out: $(TESTDIR)/%.f90 $(STATIC)
-		mkdir -p $(EXEDIR)
-		$(FC) $(FFLAGS) $< $(MODIN) -o $@ $(STATIC)
+$(SHARED): $(SRCS)
+	mkdir -p $(MODDIR)
+	$(FC) $(FFLAGS) -fpic -shared $(MODOUT) -o $@ $<
 
-$(EXEDIR)/%.out: $(EXMPLDIR)/%.f90 $(STATIC)
-		mkdir -p $(EXEDIR)
-		$(FC) $(FFLAGS) $< $(MODIN) -o $@ $(STATIC)
+$(EXEDIRSTATIC)/%.out: $(TESTDIR)/%.f90 $(STATIC)
+	mkdir -p $(EXEDIRSTATIC)
+	$(FC) $(FFLAGS) $< $(MODIN) -o $@ $(STATIC)
 
-test: $(TESTEXES) $(EXMPLEXES)
-		@for f in $(TESTEXES) $(EXMPLEXES); do $$f; done
+$(EXEDIRSTATIC)/%.out: $(EXMPLDIR)/%.f90 $(STATIC)
+	mkdir -p $(EXEDIRSTATIC)
+	$(FC) $(FFLAGS) $< $(MODIN) -o $@ $(STATIC)
+
+$(EXEDIRSHARED)/%.out: $(TESTDIR)/%.f90 $(SHARED)
+	mkdir -p $(EXEDIRSHARED)
+	$(FC) $(FFLAGS) $< $(MODIN) -o $@ $(SHARED)
+
+$(EXEDIRSHARED)/%.out: $(EXMPLDIR)/%.f90 $(SHARED)
+	mkdir -p $(EXEDIRSHARED)
+	$(FC) $(FFLAGS) $< $(MODIN) -o $@ $(SHARED)
+
+test: $(TESTEXESSTATIC) $(TESTEXESSHARED) $(EXMPLEXESSTATIC) $(EXMPLEXESSHARED)
+	@for f in $^; do $$f; done
 
 clean:
-		rm -rf $(BUILDDIR)
-		rm -f $(STATIC)
+	rm -rf $(BUILDDIR)
+	rm -f $(STATIC)
+	rm -f $(SHARED)

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ ifeq ($(FC),gfortran)
 	MODOUT := -J$(MODDIR)
 else
 	MODIN := -module $(MODDIR)
-	MODOUT := MODIN
+	MODOUT := $(MODIN)
 endif
 
 all: $(STATIC) $(SHARED)

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ all: $(STATIC) $(SHARED)
 static: $(STATIC)
 shared: $(SHARED)
 
-$(OBJS): $(SRCS)
+$(OBJDIR)/%.o: $(SRCDIR)/%.f90
 	mkdir -p $(MODDIR) $(OBJDIR)
 	$(FC) $(FFLAGS) $(MODOUT) -c $< -o $@
 

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ all: $(STATIC) $(SHARED)
 static: $(STATIC)
 shared: $(SHARED)
 
-$(OBJDIR)/%.o: $(SRCDIR)/%.f90
+$(OBJS): $(SRCS)
 	mkdir -p $(MODDIR) $(OBJDIR)
 	$(FC) $(FFLAGS) $(MODOUT) -c $< -o $@
 

--- a/Makefile
+++ b/Makefile
@@ -63,19 +63,19 @@ $(SHARED): $(SRCS)
 
 $(EXEDIRSTATIC)/%.out: $(TESTDIR)/%.f90 $(STATIC)
 	mkdir -p $(EXEDIRSTATIC)
-	$(FC) $(FFLAGS) $< $(MODIN) -o $@ $(STATIC)
+	$(FC) $(FFLAGS) $(MODIN) -o $@ $< $(STATIC)
 
 $(EXEDIRSTATIC)/%.out: $(EXMPLDIR)/%.f90 $(STATIC)
 	mkdir -p $(EXEDIRSTATIC)
-	$(FC) $(FFLAGS) $< $(MODIN) -o $@ $(STATIC)
+	$(FC) $(FFLAGS) $(MODIN) -o $@ $< $(STATIC)
 
 $(EXEDIRSHARED)/%.out: $(TESTDIR)/%.f90 $(SHARED)
 	mkdir -p $(EXEDIRSHARED)
-	$(FC) $(FFLAGS) $< $(MODIN) -o $@ $(SHARED)
+	$(FC) $(FFLAGS) -L. $(MODIN) -o $@ $< $(SHARED)
 
 $(EXEDIRSHARED)/%.out: $(EXMPLDIR)/%.f90 $(SHARED)
 	mkdir -p $(EXEDIRSHARED)
-	$(FC) $(FFLAGS) $< $(MODIN) -o $@ $(SHARED)
+	$(FC) $(FFLAGS) -L. $(MODIN) -o $@ $< $(SHARED)
 
 test: $(TESTEXESSTATIC) $(TESTEXESSHARED) $(EXMPLEXESSTATIC) $(EXMPLEXESSHARED)
 	@for f in $^; do $$f; done

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ $(OBJDIR)/%.o: $(SRCDIR)/%.f90
 	$(FC) $(FFLAGS) $(MODOUT) -c $< -o $@
 
 $(STATIC): $(OBJS)
-	$(AR) $(ARFLAGS) $@ $(OBJS)
+	$(AR) $(ARFLAGS) $@ $<
 
 $(SHARED): $(SRCS)
 	mkdir -p $(MODDIR)
@@ -60,19 +60,19 @@ $(SHARED): $(SRCS)
 
 $(EXEDIRSTATIC)/%.out: $(TESTDIR)/%.f90 $(STATIC)
 	mkdir -p $(EXEDIRSTATIC)
-	$(FC) $(FFLAGS) $(MODIN) -o $@ $< $(STATIC)
+	$(FC) $(FFLAGS) $(MODIN) -o $@ $^
 
 $(EXEDIRSTATIC)/%.out: $(EXMPLDIR)/%.f90 $(STATIC)
 	mkdir -p $(EXEDIRSTATIC)
-	$(FC) $(FFLAGS) $(MODIN) -o $@ $< $(STATIC)
+	$(FC) $(FFLAGS) $(MODIN) -o $@ $^
 
 $(EXEDIRSHARED)/%.out: $(TESTDIR)/%.f90 $(SHARED)
 	mkdir -p $(EXEDIRSHARED)
-	$(FC) $(FFLAGS) $(MODIN) -o $@ $< $(SHARED) $(LDFLAGS)
+	$(FC) $(FFLAGS) $(MODIN) -o $@ $^ $(LDFLAGS)
 
 $(EXEDIRSHARED)/%.out: $(EXMPLDIR)/%.f90 $(SHARED)
 	mkdir -p $(EXEDIRSHARED)
-	$(FC) $(FFLAGS) $(MODIN) -o $@ $< $(SHARED)	$(LDFLAGS)
+	$(FC) $(FFLAGS) $(MODIN) -o $@ $^ $(LDFLAGS)
 
 test: $(TESTEXESSTATIC) $(TESTEXESSHARED) $(EXMPLEXESSTATIC) $(EXMPLEXESSHARED)
 	@for f in $^; do $$f; done

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,7 @@ EXMPLDIR := example
 BUILDDIR := build/Makefile
 MODDIR := $(BUILDDIR)/mod
 OBJDIR := $(BUILDDIR)/obj
-EXEDIRSTATIC := $(BUILDDIR)/exe/static
-EXEDIRSHARED := $(BUILDDIR)/exe/shared
+EXEDIR := $(BUILDDIR)/exe
 
 ifeq ($(FC),gfortran)
 	MODIN := -I$(MODDIR)
@@ -38,10 +37,10 @@ SRCS := $(wildcard $(SRCDIR)/*.f90)
 TESTSRCS := $(wildcard $(TESTDIR)/*.f90)
 EXMPLSRCS := $(wildcard $(EXMPLDIR)/*.f90)
 OBJS := $(patsubst $(SRCDIR)/%.f90,$(OBJDIR)/%.o,$(SRCS))
-TESTEXESSTATIC := $(patsubst $(TESTDIR)/%.f90,$(EXEDIRSTATIC)/%.out,$(TESTSRCS))
-TESTEXESSHARED := $(patsubst $(TESTDIR)/%.f90,$(EXEDIRSHARED)/%.out,$(TESTSRCS))
-EXMPLEXESSTATIC := $(patsubst $(EXMPLDIR)/%.f90,$(EXEDIRSTATIC)/%.out,$(EXMPLSRCS))
-EXMPLEXESSHARED := $(patsubst $(EXMPLDIR)/%.f90,$(EXEDIRSHARED)/%.out,$(EXMPLSRCS))
+TESTEXESSTATIC := $(patsubst $(TESTDIR)/%.f90,$(EXEDIR)/%_static.out,$(TESTSRCS))
+TESTEXESSHARED := $(patsubst $(TESTDIR)/%.f90,$(EXEDIR)/%_shared.out,$(TESTSRCS))
+EXMPLEXESSTATIC := $(patsubst $(EXMPLDIR)/%.f90,$(EXEDIR)/%_static.out,$(EXMPLSRCS))
+EXMPLEXESSHARED := $(patsubst $(EXMPLDIR)/%.f90,$(EXEDIR)/%_shared.out,$(EXMPLSRCS))
 
 all: $(STATIC) $(SHARED)
 static: $(STATIC)
@@ -58,20 +57,20 @@ $(SHARED): $(SRCS)
 	mkdir -p $(MODDIR)
 	$(FC) $(FFLAGS) -fpic -shared $(MODOUT) -o $@ $<
 
-$(EXEDIRSTATIC)/%.out: $(TESTDIR)/%.f90 $(STATIC)
-	mkdir -p $(EXEDIRSTATIC)
+$(EXEDIR)/%_static.out: $(TESTDIR)/%.f90 $(STATIC)
+	mkdir -p $(EXEDIR)
 	$(FC) $(FFLAGS) $(MODIN) -o $@ $^
 
-$(EXEDIRSTATIC)/%.out: $(EXMPLDIR)/%.f90 $(STATIC)
-	mkdir -p $(EXEDIRSTATIC)
+$(EXEDIR)/%_static.out: $(EXMPLDIR)/%.f90 $(STATIC)
+	mkdir -p $(EXEDIR)
 	$(FC) $(FFLAGS) $(MODIN) -o $@ $^
 
-$(EXEDIRSHARED)/%.out: $(TESTDIR)/%.f90 $(SHARED)
-	mkdir -p $(EXEDIRSHARED)
+$(EXEDIR)/%_shared.out: $(TESTDIR)/%.f90 $(SHARED)
+	mkdir -p $(EXEDIR)
 	$(FC) $(FFLAGS) $(MODIN) -o $@ $^ $(LDFLAGS)
 
-$(EXEDIRSHARED)/%.out: $(EXMPLDIR)/%.f90 $(SHARED)
-	mkdir -p $(EXEDIRSHARED)
+$(EXEDIR)/%_shared.out: $(EXMPLDIR)/%.f90 $(SHARED)
+	mkdir -p $(EXEDIR)
 	$(FC) $(FFLAGS) $(MODIN) -o $@ $^ $(LDFLAGS)
 
 test: $(TESTEXESSTATIC) $(TESTEXESSHARED) $(EXMPLEXESSTATIC) $(EXMPLEXESSHARED)

--- a/Makefile
+++ b/Makefile
@@ -71,11 +71,11 @@ $(EXEDIRSTATIC)/%.out: $(EXMPLDIR)/%.f90 $(STATIC)
 
 $(EXEDIRSHARED)/%.out: $(TESTDIR)/%.f90 $(SHARED)
 	mkdir -p $(EXEDIRSHARED)
-	$(FC) $(FFLAGS) $(MODIN) -o $@ $< $(SHARED) -Wl,-rpath=../../../..
+	$(FC) $(FFLAGS) $(MODIN) -o $@ $< $(SHARED) -Wl,-rpath=.
 
 $(EXEDIRSHARED)/%.out: $(EXMPLDIR)/%.f90 $(SHARED)
 	mkdir -p $(EXEDIRSHARED)
-	$(FC) $(FFLAGS) $(MODIN) -o $@ $< $(SHARED) -Wl,-rpath=../../../..
+	$(FC) $(FFLAGS) $(MODIN) -o $@ $< $(SHARED) -Wl,-rpath=.
 
 test: $(TESTEXESSTATIC) $(TESTEXESSHARED) $(EXMPLEXESSTATIC) $(EXMPLEXESSHARED)
 	@for f in $^; do $$f; done


### PR DESCRIPTION
- [x] Build shared libraries with `Makefile`.
- [x] Test executables generated from both static and shared libraries.
- [x] Use safer operator for assignments throughout `Makefile`.
- [x] Clean up `Makefile` a bit (better ordering, less indentation).
- [x] Fix option for module in- and output for Intel compilers.