### PR TITLE
Properly use tabs in `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,10 @@ NAME := version-f
 STATIC := lib$(NAME).a
 
 ifeq ($(shell uname), Linux)
-    SHARED := lib$(NAME).so
+	SHARED := lib$(NAME).so
 	LDFLAGS := -Wl,-rpath=.
 else ifeq ($(shell uname), Darwin)
-    SHARED := lib$(NAME).dylib
+	SHARED := lib$(NAME).dylib
 endif
 
 SRCDIR := src


### PR DESCRIPTION
- [x] Use tabs instead of spaces in `Makefile`