### PR TITLE
Fix verbose warnings in examples

### DIFF
--- a/example/version_f_ex1.f90
+++ b/example/version_f_ex1.f90
@@ -15,7 +15,7 @@ program ex1
   type(version_t) :: highest_version
   integer :: i
 
-  allocate(loaded_boxes(0))
+  allocate (loaded_boxes(0))
   call load_boxes(loaded_boxes)
 
   ! Create and register versions

--- a/example/version_f_ex1.f90
+++ b/example/version_f_ex1.f90
@@ -15,6 +15,7 @@ program ex1
   type(version_t) :: highest_version
   integer :: i
 
+  allocate(loaded_boxes(0))
   call load_boxes(loaded_boxes)
 
   ! Create and register versions

--- a/example/version_f_ex2.f90
+++ b/example/version_f_ex2.f90
@@ -10,7 +10,7 @@ program ex2
   type(version_t), allocatable :: greater_versions(:)
   integer :: i
 
-  allocate(all_versions(0))
+  allocate (all_versions(0))
   call load_versions(all_versions)
 
   allocate (smaller_versions(0))

--- a/example/version_f_ex2.f90
+++ b/example/version_f_ex2.f90
@@ -10,6 +10,7 @@ program ex2
   type(version_t), allocatable :: greater_versions(:)
   integer :: i
 
+  allocate(all_versions(0))
   call load_versions(all_versions)
 
   allocate (smaller_versions(0))


### PR DESCRIPTION
- [x] Fix verbose warnings that occur with `-Wall`, `-Wextra` and `-Wpedantic`