### PR TITLE
Fix semver leading zero validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ call v1%increment_prerelease() ! 0.5.4-2
 
 ## Build metadata
 
-`build` metadata can be included and will be appended after the `patch` or the `prerelease` via a `+` sign. The identifiers must comprise only ASCII alphanumerics and hyphens `[0-9A-Za-z-]` and are separated by dots. Numerical identifiers must not start with a `0` digit. `build` data is not used for comparison and it is cleared every time a `major`, `minor`, `patch` or `prerelease` version is incremented. A `build` value can be [incremented](#increment-versions).
+`build` metadata can be included and will be appended after the `patch` or the `prerelease` via a `+` sign. The identifiers must comprise only ASCII alphanumerics and hyphens `[0-9A-Za-z-]` and are separated by dots. Build identifiers may contain leading zeroes. `build` data is not used for comparison and it is cleared every time a `major`, `minor`, `patch` or `prerelease` version is incremented. A `build` value can be [incremented](#increment-versions).
 
 ```fortran
 type(version_t) :: v1, v2

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ end
 
 ## Strict mode
 
-In `strict_mode` (optional parameter in `create`, `parse` and `is_version`), all `major`, `minor` and `patch` numbers must be provided. Implicit zeros are forbidden.
+In `strict_mode` (optional parameter in `create`, `parse` and `is_version`), all `major`, `minor` and `patch` numbers must be provided. Implicit zeros and leading zeroes are forbidden.
 
 ```fortran
 type(version_t) :: version

--- a/src/version_f.f90
+++ b/src/version_f.f90
@@ -390,8 +390,8 @@ contains
   !>
   !> Can be invoked by calling the default constructor.
   !>
-  !> In strict mode, all major, minor and patch versions must be provided. Implicit
-  !> zeros are forbidden in strict mode.
+  !> In strict mode, all major, minor and patch versions must be provided.
+  !> Implicit zeros and leading zeroes are forbidden in strict mode.
   function parse(str, strict_mode) result(version)
     character(*), intent(in) :: str
     logical, optional, intent(in) :: strict_mode
@@ -405,7 +405,7 @@ contains
 
   !> Attempt to parse a string into a version including prerelease and build
   !> data. In strict mode, all major, minor and patch versions must be provided.
-  !> Implicit zeros are forbidden in strict mode.
+  !> Implicit zeros and leading zeroes are forbidden in strict mode.
   subroutine try_parse(this, string, error, strict_mode)
     class(version_t), intent(out) :: this
     character(*), intent(in) :: string
@@ -478,6 +478,10 @@ contains
       if (is_strict_mode .and. i == 1) then
         error = error_t('Strict mode: Major version must be a number.'); return
       end if
+      if (is_strict_mode) then
+        call validate_core_number(str(1:i - 1), error)
+        if (allocated(error)) return
+      end if
       call s2int(str(1:i - 1), this%major, error)
       if (allocated(error)) return
       j = index(str(i + 1:l), '.')
@@ -491,13 +495,33 @@ contains
         if (is_strict_mode .and. j == 1) then
           error = error_t('Strict mode: Minor version must be a number.'); return
         end if
+        if (is_strict_mode) then
+          call validate_core_number(str(i + 1:i + j - 1), error)
+          if (allocated(error)) return
+        end if
         call s2int(str(i + 1:i + j - 1), this%minor, error)
         if (allocated(error)) return
         if (is_strict_mode .and. len(str) == i + j) then
           error = error_t('Strict mode: Patch version must be a number.'); return
         end if
+        if (is_strict_mode) then
+          call validate_core_number(str(i + j + 1:l), error)
+          if (allocated(error)) return
+        end if
         call s2int(str(i + j + 1:l), this%patch, error)
         if (allocated(error)) return
+      end if
+    end if
+  end
+
+  !> Reject leading zeroes in a major, minor or patch number.
+  pure subroutine validate_core_number(str, error)
+    character(*), intent(in) :: str
+    type(error_t), allocatable, intent(out) :: error
+
+    if (len(str) > 1) then
+      if (str(1:1) == '0') then
+        error = error_t('Strict mode: Version numbers must not contain leading zeroes.')
       end if
     end if
   end

--- a/src/version_f.f90
+++ b/src/version_f.f90
@@ -141,7 +141,8 @@ contains
   !> Prelease and build versions are entered through a series of dot-separated
   !> identifiers. The identifiers must be composed of ASCII letters, digits or
   !> hyphens. They must not be empty and must not begin or end with
-  !> with a dot. Numerical identifiers must not start with a zero.
+  !> with a dot. Multi-digit numerical prerelease identifiers must not start
+  !> with a zero. Build identifiers may contain leading zeroes.
   !>
   !> Valid examples:
   !>
@@ -218,12 +219,12 @@ contains
     end if
 
     if (present(prerelease)) then
-      call build_identifiers(this%prerelease, prerelease, error)
+      call build_identifiers(this%prerelease, prerelease, .true., error)
       if (allocated(error)) return
     end if
 
     if (present(build)) then
-      call build_identifiers(this%build, build, error)
+      call build_identifiers(this%build, build, .false., error)
       if (allocated(error)) return
     end if
   end
@@ -424,17 +425,17 @@ contains
     else if (i /= 0 .and. j == 0) then
       call build_mmp(this, str(1:i - 1), error, strict_mode)
       if (allocated(error)) return
-      call build_identifiers(this%prerelease, str(i + 1:len_trim(str)), error); return
+      call build_identifiers(this%prerelease, str(i + 1:len_trim(str)), .true., error); return
     else if ((i == 0 .and. j /= 0) .or. ((i /= 0 .and. j /= 0) .and. (i > j))) then
       call build_mmp(this, str(1:j - 1), error, strict_mode)
       if (allocated(error)) return
-      call build_identifiers(this%build, str(j + 1:len_trim(str)), error); return
+      call build_identifiers(this%build, str(j + 1:len_trim(str)), .false., error); return
     else if (i /= 0 .and. j /= 0) then
       call build_mmp(this, str(1:i - 1), error, strict_mode)
       if (allocated(error)) return
-      call build_identifiers(this%prerelease, str(i + 1:j - 1), error)
+      call build_identifiers(this%prerelease, str(i + 1:j - 1), .true., error)
       if (allocated(error)) return
-      call build_identifiers(this%build, str(j + 1:len_trim(str)), error); return
+      call build_identifiers(this%build, str(j + 1:len_trim(str)), .false., error); return
     end if
   end
 
@@ -572,8 +573,9 @@ contains
 
   !> Validate prerelease or build identifier string without allocating. Uses an
   !> ASCII lookup table for O(1) character validation instead of O(m) scans.
-  pure subroutine validate_identifiers(str, error)
+  pure subroutine validate_identifiers(str, is_prerelease, error)
     character(*), intent(in) :: str
+    logical, intent(in) :: is_prerelease
     type(error_t), allocatable, intent(out) :: error
 
     integer :: i, c, start, length
@@ -608,10 +610,10 @@ contains
     do
       length = index(str(start:), '.')
       if (length == 0) then
-        call validate_identifier(str(start:), error)
+        call validate_identifier(str(start:), is_prerelease, error)
         return
       else
-        call validate_identifier(str(start:start + length - 2), error)
+        call validate_identifier(str(start:start + length - 2), is_prerelease, error)
         if (allocated(error)) return
         start = start + length
       end if
@@ -620,14 +622,15 @@ contains
 
   !> Check for valid prerelease or build data and build identifiers from
   !> the string.
-  pure subroutine build_identifiers(ids, str, error)
+  pure subroutine build_identifiers(ids, str, is_prerelease, error)
     type(string_t), allocatable, intent(out) :: ids(:)
     character(*), intent(in) :: str
+    logical, intent(in) :: is_prerelease
     type(error_t), allocatable, intent(out) :: error
 
     integer :: i, n, start, length
 
-    call validate_identifiers(str, error)
+    call validate_identifiers(str, is_prerelease, error)
     if (allocated(error)) return
 
     ! Count identifiers.
@@ -651,8 +654,9 @@ contains
   end
 
   !> Validate an identifier.
-  pure subroutine validate_identifier(str, error)
+  pure subroutine validate_identifier(str, is_prerelease, error)
     character(*), intent(in) :: str
+    logical, intent(in) :: is_prerelease
     type(error_t), allocatable, intent(out) :: error
 
     ! Empty identifiers are not allowed.
@@ -665,9 +669,11 @@ contains
       error = error_t("Identifiers must not start with '.'"); return
     end if
 
-    ! Numerical identifiers must not start with 0.
-    if (is_numerical(str) .and. str(1:1) == '0') then
-      error = error_t("Numerical identifiers must not start with '0'."); return
+    ! Multi-digit numerical prerelease identifiers must not start with zero.
+    if (is_prerelease .and. len(str) > 1) then
+      if (is_numerical(str) .and. str(1:1) == '0') then
+        error = error_t("Numerical prerelease identifiers must not contain leading zeroes."); return
+      end if
     end if
   end
 
@@ -859,18 +865,18 @@ contains
     else if (i /= 0 .and. j == 0) then
       call build_mmp(version, trimmed(1:i - 1), error, strict_mode)
       if (allocated(error)) return
-      call validate_identifiers(trimmed(i + 1:len_trim(trimmed)), error)
+      call validate_identifiers(trimmed(i + 1:len_trim(trimmed)), .true., error)
     else if ((i == 0 .and. j /= 0) .or. &
             & ((i /= 0 .and. j /= 0) .and. (i > j))) then
       call build_mmp(version, trimmed(1:j - 1), error, strict_mode)
       if (allocated(error)) return
-      call validate_identifiers(trimmed(j + 1:len_trim(trimmed)), error)
+      call validate_identifiers(trimmed(j + 1:len_trim(trimmed)), .false., error)
     else if (i /= 0 .and. j /= 0) then
       call build_mmp(version, trimmed(1:i - 1), error, strict_mode)
       if (allocated(error)) return
-      call validate_identifiers(trimmed(i + 1:j - 1), error)
+      call validate_identifiers(trimmed(i + 1:j - 1), .true., error)
       if (allocated(error)) return
-      call validate_identifiers(trimmed(j + 1:len_trim(trimmed)), error)
+      call validate_identifiers(trimmed(j + 1:len_trim(trimmed)), .false., error)
     end if
   end
 

--- a/test/version_f_test.f90
+++ b/test/version_f_test.f90
@@ -1701,6 +1701,23 @@ program test
   call v1%parse('0.0.0-alpha+build', e, strict_mode=.true.)
   if (allocated(e)) call fail(e%msg)
 
+  call v1%parse('01.2.3', e, strict_mode=.true.)
+  if (.not. allocated(e)) call fail('Strict mode: Leading zero in major version.')
+
+  call v1%parse('1.02.3', e, strict_mode=.true.)
+  if (.not. allocated(e)) call fail('Strict mode: Leading zero in minor version.')
+
+  call v1%parse('1.2.03', e, strict_mode=.true.)
+  if (.not. allocated(e)) call fail('Strict mode: Leading zero in patch version.')
+
+  if (is_version('01.2.3', strict_mode=.true.)) call fail('Strict mode: Leading zero in major version accepted.')
+  if (is_version('1.02.3', strict_mode=.true.)) call fail('Strict mode: Leading zero in minor version accepted.')
+  if (is_version('1.2.03', strict_mode=.true.)) call fail('Strict mode: Leading zero in patch version accepted.')
+
+  call v1%parse('01.02.03', e, strict_mode=.false.)
+  if (allocated(e)) call fail('No strict mode: Leading zeroes should be accepted.')
+  if (v1%to_string() /= '1.2.3') call fail('No strict mode: Leading zeroes should be normalized.')
+
 !###################### is_greater overflow fallback ##########################!
 
   v1 = version_t(0, 0, 0, '99999999999')

--- a/test/version_f_test.f90
+++ b/test/version_f_test.f90
@@ -88,7 +88,8 @@ program test
   if (.not. allocated(e)) call fail('Invalid prerelease missed.')
 
   call v1%create(1, prerelease='abc.ded', build='05567.abc', error=e)
-  if (.not. allocated(e)) call fail('Invalid build missed.')
+  if (allocated(e)) call fail('Numeric build identifier with leading zeroes should be valid.')
+  if (v1%to_string() /= '1.0.0-abc.ded+05567.abc') call fail('Build identifier with leading zeroes changed.')
 
   v1 = version_t(0, 1, 0, prerelease='abc.def---', build='0---789.abc')
   if (v1%to_string() /= '0.1.0-abc.def---+0---789.abc') then
@@ -132,7 +133,7 @@ program test
   end if
 
   call v1%create(1, prerelease='d', build='9.0', error=e)
-  if (.not. allocated(e)) call fail('Invalid build missed.')
+  if (allocated(e)) call fail('Zero build identifier should be valid.')
 
 !################################# Increment ##################################!
 
@@ -383,16 +384,18 @@ program test
   end if
 
   call v1%parse('1-0', e)
-  if (.not. allocated(e)) call fail('Leading zero identifier not allowed.')
+  if (allocated(e)) call fail('A single zero prerelease identifier should be valid.')
 
   call v1%parse('1-hff.08', e)
   if (.not. allocated(e)) call fail('Leading zero identifier not allowed.')
 
   call v1%parse('1-hff.87+08', e)
-  if (.not. allocated(e)) call fail('Leading zero identifier not allowed.')
+  if (allocated(e)) call fail('Build identifier with leading zeroes should be valid.')
+  if (v1%to_string() /= '1.0.0-hff.87+08') call fail('Build identifier with leading zeroes changed.')
 
   call v1%parse('1-hff.87+fejf.08', e)
-  if (.not. allocated(e)) call fail('Leading zero identifier not allowed.')
+  if (allocated(e)) call fail('Build identifier with leading zeroes should be valid.')
+  if (v1%to_string() /= '1.0.0-hff.87+fejf.08') call fail('Build identifier with leading zeroes changed.')
 
   call v1%parse('1-..', e)
   if (.not. allocated(e)) call fail('No consecutive dots.')
@@ -805,7 +808,7 @@ program test
   if (is_version('1.0.0-(')) call fail("'1.0.0-(' isn't a version.")
   if (is_version('1.0.0-')) call fail("'1.0.0-' isn't a version.")
   if (is_version('1.0.0-+')) call fail("'1.0.0-+' isn't a version.")
-  if (is_version('1.0.0-0')) call fail("'1.0.0-' isn't a version.")
+  if (.not. is_version('1.0.0-0')) call fail("'1.0.0-0' is a version.")
   if (is_version('1.0.0-ab..cd')) call fail("'1.0.0-ab..cd' isn't a version.")
   if (is_version('...')) call fail("'...' isn't a version.")
   if (is_version('-')) call fail("'-' isn't a version.")


### PR DESCRIPTION
- [x] Allow leading zeroes in build metadata
- [x] Reject leading zeroes in strict version