### PR TITLE
Reduce the public API surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The components of `version_t` are private so that a version cannot be placed in
 an invalid state through direct assignment. Use `major()`, `minor()`, `patch()`,
 `prerelease()` and `build()` to inspect them. A default
 constructed `version_t` is initialized to `0.0.0`. Identifier accessors return
-copies, using an empty array when no identifiers are present.
+dot-separated strings, or an empty string when no identifiers are present.
 
 ### make
 
@@ -203,6 +203,15 @@ program main
 end
 ```
 
+Parse a `version_range_t` once to reuse it:
+
+```fortran
+type(version_range_t) :: range
+
+call range%parse('>=1.0.0 <2.0.0', error)
+print *, range%satisfies(version_t(1, 5, 0)) ! true
+```
+
 ## Strict mode
 
 In `strict_mode` (optional parameter in `create`, `parse` and `is_version`), all `major`, `minor` and `patch` numbers must be provided. Implicit zeros and leading zeroes are forbidden. Without strict mode, missing numbers become zero. Input is trimmed in both modes.
@@ -248,7 +257,7 @@ procedure to handle the error instead:
 type(error_t), allocatable :: error
 
 call version%try_increment_major(error)
-if (allocated(error)) print *, error%msg
+if (allocated(error)) print *, error%message()
 ```
 
 ## is_version()
@@ -353,6 +362,13 @@ indentation width of 2 or run `fprettify -i 2 -r .` before committing.
 Feel free to [create an issue](https://github.com/minhqdao/version-f/issues) in case you found a bug, have any questions or
 want to propose further improvements. Please stick to the existing coding style
 when you open a pull request.
+
+## API stability
+
+Before version 1.0, public APIs may change in minor releases. Breaking changes
+will be noted in the release notes. Deprecated APIs will be kept for one minor
+release when practical. After version 1.0, breaking changes require a new major
+version.
 
 ## License
 

--- a/src/version_f.f90
+++ b/src/version_f.f90
@@ -5,21 +5,14 @@ module version_f
   implicit none
   private
 
-  public :: version_t, string_t, error_t, is_version, version_range_t, &
-            comparator_set_t, comparator_t
+  public :: version_t, error_t, is_version, version_range_t
 
   type :: string_t
     character(:), allocatable :: str
   contains
-    generic :: num => string_t_2i
-    procedure, private :: string_t_2i
     generic :: is_numeric => string_t_is_numeric
     procedure, private :: string_t_is_numeric
   end type
-
-  interface string_t
-    module procedure :: create_string_t
-  end interface
 
   !> Contains all version information.
   type :: version_t
@@ -43,13 +36,15 @@ module version_f
     & increment_prerelease, increment_build, try_increment_major, &
     & try_increment_minor, try_increment_patch, try_increment_prerelease, &
     & try_increment_build, is_exactly, satisfies, try_satisfy, &
-    & satisfies_comp_set, satisfies_comp, is_stable
+    & is_stable
 
     generic :: create => try_create
     procedure, private :: try_create
 
     generic :: parse => try_parse
     procedure, private :: try_parse
+
+    procedure, private :: satisfies_comp_set, satisfies_comp
 
     generic :: operator(==) => equals
     procedure, private :: equals
@@ -75,7 +70,10 @@ module version_f
   end interface
 
   type :: error_t
-    character(:), allocatable :: msg
+    private
+    character(:), allocatable :: msg_
+  contains
+    procedure :: message => error_message
   end type
 
   interface error_t
@@ -83,36 +81,29 @@ module version_f
   end interface
 
   type :: comparator_t
+    private
     character(:), allocatable :: op
     type(version_t) :: version
   contains
     procedure, private :: parse_comp_and_crop_str
   end type
 
-  interface comparator_t
-    module procedure :: create_comp
-  end interface
-
   type :: comparator_set_t
+    private
     type(comparator_t), allocatable :: comps(:)
   contains
     generic :: parse => parse_comp_set
     procedure, private :: parse_comp_set
-    generic :: extend_with => extend_comps
-    procedure, private :: extend_comps
   end type
 
-  interface comparator_set_t
-    module procedure :: create_comp_set
-  end interface
-
   type :: version_range_t
+    private
     type(comparator_set_t), allocatable :: comp_sets(:)
   contains
     generic :: parse => parse_version_range
     procedure, private :: parse_version_range
-    generic :: extend_with => extend_comp_sets
-    procedure, private :: extend_comp_sets
+    procedure :: satisfies => range_satisfies
+    procedure :: try_satisfy => range_try_satisfy
   end type
 
 contains
@@ -134,7 +125,7 @@ contains
     type(error_t), allocatable :: error
 
     call try_create(this, major, minor, patch, prerelease, build, error, strict_mode)
-    if (allocated(error)) error stop error%msg
+    if (allocated(error)) error stop error%msg_
   end
 
   !> Create a version from individual major, minor, patch, prerelease and build
@@ -326,28 +317,53 @@ contains
     patch = this%patch_
   end
 
-  !> Return a copy of the prerelease identifiers.
-  pure function prerelease(this) result(identifiers)
+  !> Return the dot-separated prerelease identifiers.
+  pure function prerelease(this) result(str)
     class(version_t), intent(in) :: this
-    type(string_t), allocatable :: identifiers(:)
+    character(:), allocatable :: str
 
     if (allocated(this%prerelease_)) then
-      identifiers = this%prerelease_
+      str = identifiers_string(this%prerelease_)
     else
-      allocate (identifiers(0))
+      str = ''
     end if
   end
 
-  !> Return a copy of the build identifiers.
-  pure function build(this) result(identifiers)
+  !> Return the dot-separated build identifiers.
+  pure function build(this) result(str)
     class(version_t), intent(in) :: this
-    type(string_t), allocatable :: identifiers(:)
+    character(:), allocatable :: str
 
     if (allocated(this%build_)) then
-      identifiers = this%build_
+      str = identifiers_string(this%build_)
     else
-      allocate (identifiers(0))
+      str = ''
     end if
+  end
+
+  !> Join an array of identifiers with dots.
+  pure function identifiers_string(identifiers) result(str)
+    type(string_t), intent(in) :: identifiers(:)
+    character(:), allocatable :: str
+
+    integer :: i, n, pos
+
+    n = 0
+    do i = 1, size(identifiers)
+      n = n + len(identifiers(i)%str)
+      if (i < size(identifiers)) n = n + 1
+    end do
+
+    allocate (character(n) :: str)
+    pos = 1
+    do i = 1, size(identifiers)
+      str(pos:pos + len(identifiers(i)%str) - 1) = identifiers(i)%str
+      pos = pos + len(identifiers(i)%str)
+      if (i < size(identifiers)) then
+        str(pos:pos) = '.'
+        pos = pos + 1
+      end if
+    end do
   end
 
   !> Increments the major version number and resets the minor and patch number
@@ -360,7 +376,7 @@ contains
     type(error_t), allocatable :: error
 
     call this%try_increment_major(error)
-    if (allocated(error)) error stop error%msg
+    if (allocated(error)) error stop error%msg_
   end
 
   !> Attempt to increment the major version, reporting overflow through `error`.
@@ -387,7 +403,7 @@ contains
     type(error_t), allocatable :: error
 
     call this%try_increment_minor(error)
-    if (allocated(error)) error stop error%msg
+    if (allocated(error)) error stop error%msg_
   end
 
   !> Attempt to increment the minor version, reporting overflow through `error`.
@@ -412,7 +428,7 @@ contains
     type(error_t), allocatable :: error
 
     call this%try_increment_patch(error)
-    if (allocated(error)) error stop error%msg
+    if (allocated(error)) error stop error%msg_
   end
 
   !> Attempt to increment the patch version, reporting overflow through `error`.
@@ -436,7 +452,7 @@ contains
     type(error_t), allocatable :: error
 
     call this%try_increment_prerelease(error)
-    if (allocated(error)) error stop error%msg
+    if (allocated(error)) error stop error%msg_
   end
 
   !> Attempt to increment prerelease data, reporting overflow through `error`.
@@ -461,7 +477,7 @@ contains
     type(error_t), allocatable :: error
 
     call this%try_increment_build(error)
-    if (allocated(error)) error stop error%msg
+    if (allocated(error)) error stop error%msg_
   end
 
   !> Attempt to increment build metadata, reporting overflow through `error`.
@@ -531,7 +547,7 @@ contains
     type(error_t), allocatable :: error
 
     call version%parse(str, error, strict_mode)
-    if (allocated(error)) error stop error%msg
+    if (allocated(error)) error stop error%msg_
   end
 
   !> Attempt to parse a string into a version including prerelease and build
@@ -682,26 +698,6 @@ contains
         error = error_t("Contains non-digit: '"//str//"'."); return
       end if
     end do
-  end
-
-  !> Wrapper function for `s2int`.
-  elemental integer function s2i(str)
-    character(*), intent(in) :: str
-
-    type(error_t), allocatable :: e
-
-    call s2int(str, s2i, e)
-    if (allocated(e)) error stop e%msg
-  end
-
-  !> Convert a `string_t` to an integer.
-  elemental integer function string_t_2i(this)
-    class(string_t), intent(in) :: this
-
-    type(error_t), allocatable :: e
-
-    call s2int(this%str, string_t_2i, e)
-    if (allocated(e)) error stop e%msg
   end
 
   !> Convert an integer to a string.
@@ -1057,18 +1053,6 @@ contains
     is_version = .not. allocated(error)
   end
 
-  !> Helper function to generate a new `string_t` instance.
-  elemental function create_string_t(inp_str) result(string)
-
-    !> Input string.
-    character(*), intent(in) :: inp_str
-
-    !> The string instance.
-    type(string_t) :: string
-
-    string%str = inp_str
-  end
-
   !> Helper function to generate a new `error_t` instance.
   elemental function create_error_t(msg) result(err)
 
@@ -1078,7 +1062,19 @@ contains
     !> The error instance.
     type(error_t) :: err
 
-    err%msg = msg
+    err%msg_ = msg
+  end
+
+  !> Return the error message.
+  pure function error_message(this) result(msg)
+    class(error_t), intent(in) :: this
+    character(:), allocatable :: msg
+
+    if (allocated(this%msg_)) then
+      msg = this%msg_
+    else
+      msg = ''
+    end if
   end
 
   !> Determine whether the version meets the comparison expressed in `str`.
@@ -1122,7 +1118,6 @@ contains
 
     character(:), allocatable :: str
     type(version_range_t) :: version_range
-    integer :: i
 
     str = trim(adjustl(string))
 
@@ -1133,10 +1128,7 @@ contains
     call version_range%parse(str, error)
     if (allocated(error)) return
 
-    do i = 1, size(version_range%comp_sets)
-      call this%satisfies_comp_set(version_range%comp_sets(i), is_satisfied, error)
-      if (is_satisfied .or. allocated(error)) return
-    end do
+    call version_range%try_satisfy(this, is_satisfied, error)
   end
 
   !> Convenience function to determine whether the version meets the comparison.
@@ -1155,6 +1147,37 @@ contains
 
     call this%try_satisfy(str, satisfies, error)
     if (allocated(error)) satisfies = .false.
+  end
+
+  !> Determine whether `version` satisfies this parsed range.
+  pure subroutine range_try_satisfy(this, version, is_satisfied, error)
+    class(version_range_t), intent(in) :: this
+    type(version_t), intent(in) :: version
+    logical, intent(out) :: is_satisfied
+    type(error_t), allocatable, intent(out) :: error
+
+    integer :: i
+
+    is_satisfied = .false.
+    if (.not. allocated(this%comp_sets)) then
+      error = error_t('Version range has not been parsed.'); return
+    end if
+
+    do i = 1, size(this%comp_sets)
+      call version%satisfies_comp_set(this%comp_sets(i), is_satisfied, error)
+      if (is_satisfied .or. allocated(error)) return
+    end do
+  end
+
+  !> Return true if `version` satisfies this parsed range.
+  pure logical function range_satisfies(this, version)
+    class(version_range_t), intent(in) :: this
+    type(version_t), intent(in) :: version
+
+    type(error_t), allocatable :: error
+
+    call this%try_satisfy(version, range_satisfies, error)
+    if (allocated(error)) range_satisfies = .false.
   end
 
   !> Create sets of comparators that are separated by `||`. An example of a
@@ -1206,19 +1229,6 @@ contains
     call comp_set%parse_comp_set(str, error)
     if (allocated(error)) return
     this%comp_sets(idx) = comp_set
-  end
-
-  !> Extend array of comparator sets within version range with another comparator.
-  subroutine extend_comp_sets(range, comp_set)
-    class(version_range_t), intent(inout) :: range
-    type(comparator_set_t), intent(in) :: comp_set
-
-    type(comparator_set_t), allocatable :: tmp(:)
-
-    allocate (tmp(size(range%comp_sets) + 1))
-    tmp(1:size(range%comp_sets)) = range%comp_sets
-    tmp(size(tmp)) = comp_set
-    call move_alloc(tmp, range%comp_sets)
   end
 
   !> Parse a set of comparators that are separated by ` ` from a string. An
@@ -1318,19 +1328,6 @@ contains
       if (str == '') return
       str = trim(adjustl(str))
     end do
-  end
-
-  !> Extend array of comparators within comparator set with another comparator.
-  subroutine extend_comps(set, comp)
-    class(comparator_set_t), intent(inout) :: set
-    type(comparator_t), intent(in) :: comp
-
-    type(comparator_t), allocatable :: tmp(:)
-
-    allocate (tmp(size(set%comps) + 1))
-    tmp(1:size(set%comps)) = set%comps
-    tmp(size(tmp)) = comp
-    call move_alloc(tmp, set%comps)
   end
 
   !> Create a comparator from a string. A comparator consists of an operator and
@@ -1446,35 +1443,6 @@ contains
       is_satisfied = .false.
       error = error_t("Invalid operator: '"//comparator%op//"'.")
     end if
-  end
-
-  !> Create instance of `comparator_t` using an operator (`op`) and a version.
-  elemental function create_comp(op, version) result(comparator)
-
-    !> The operator of the comparator.
-    character(*), intent(in) :: op
-
-    !> The version of the comparator.
-    type(version_t), intent(in) :: version
-
-    !> Instance of `comparator_t` created from `op` and `version`.
-    type(comparator_t) :: comparator
-
-    comparator%op = op
-    comparator%version = version
-  end
-
-  !> Create instance of `comparator_set_t` using an array of comparators.
-  pure function create_comp_set(comps) result(comp_set)
-
-    !> Array of comparators to create the set from.
-    type(comparator_t), intent(in) :: comps(:)
-
-    !> Instance of `comparator_set_t` created from `comps`.
-    type(comparator_set_t) :: comp_set
-
-    allocate (comp_set%comps(size(comps)))
-    comp_set%comps = comps
   end
 
   !> Returns true if the version is stable. A version is stable if its major

--- a/test/version_f_test.f90
+++ b/test/version_f_test.f90
@@ -5,11 +5,8 @@ program test
 
   type(version_t) :: v1, v2
   logical :: is_satisfied
-  type(comparator_t), allocatable :: comps(:)
-  type(comparator_set_t) :: comp_set
   type(version_range_t) :: range
   type(error_t), allocatable :: e
-  type(string_t), allocatable :: identifiers(:)
   character(:), allocatable :: long_input
   character(32) :: huge_str
 
@@ -19,10 +16,8 @@ program test
   if (v1%major() /= 0) call fail('Default major version should be zero')
   if (v1%minor() /= 0) call fail('Default minor version should be zero')
   if (v1%patch() /= 0) call fail('Default patch version should be zero')
-  identifiers = v1%prerelease()
-  if (size(identifiers) /= 0) call fail('Default version should not have prerelease identifiers')
-  identifiers = v1%build()
-  if (size(identifiers) /= 0) call fail('Default version should not have build identifiers')
+  if (v1%prerelease() /= '') call fail('Default version should not have prerelease identifiers')
+  if (v1%build() /= '') call fail('Default version should not have build identifiers')
 
   v1 = version_t(0, 0, 0)
   if (v1%to_string() /= '0.0.0') then
@@ -84,14 +79,8 @@ program test
   if (.not. allocated(e)) call fail('Invalid character.')
 
   v1 = version_t(1, 5, 3, 'abc', '789')
-  identifiers = v1%prerelease()
-  if (.not. allocated(identifiers)) call fail('Prerelease accessor returned no identifiers')
-  if (size(identifiers) /= 1 .or. identifiers(1)%str /= 'abc') call fail('Prerelease accessor returned wrong data')
-  identifiers = v1%build()
-  if (.not. allocated(identifiers)) call fail('Build accessor returned no identifiers')
-  if (size(identifiers) /= 1 .or. identifiers(1)%str /= '789') call fail('Build accessor returned wrong data')
-  identifiers(1)%str = 'changed'
-  if (v1%to_string() /= '1.5.3-abc+789') call fail('Changing accessor result mutated the version')
+  if (v1%prerelease() /= 'abc') call fail('Prerelease accessor returned wrong data')
+  if (v1%build() /= '789') call fail('Build accessor returned wrong data')
   if (v1%to_string() /= '1.5.3-abc+789') then
     call fail("Parsing failed for '"//v1%to_string()//"'")
   end if
@@ -283,49 +272,49 @@ program test
 
   call v1%parse('0', e)
   if (allocated(e)) then
-    call fail(e%msg)
+    call fail(e%message())
   else if (v1%to_string() /= '0.0.0') then
     call fail("Parsing failed for '"//v1%to_string()//"'")
   end if
 
   call v1%parse('.', e)
   if (allocated(e)) then
-    call fail(e%msg)
+    call fail(e%message())
   else if (v1%to_string() /= '0.0.0') then
     call fail("Parsing failed for '"//v1%to_string()//"'")
   end if
 
   call v1%parse('0.1', e)
   if (allocated(e)) then
-    call fail(e%msg)
+    call fail(e%message())
   else if (v1%to_string() /= '0.1.0') then
     call fail("Parsing failed for '"//v1%to_string()//"'")
   end if
 
   call v1%parse('..988', e)
   if (allocated(e)) then
-    call fail(e%msg)
+    call fail(e%message())
   else if (v1%to_string() /= '0.0.988') then
     call fail("Parsing failed for '"//v1%to_string()//"'")
   end if
 
   call v1%parse('1..988', e)
   if (allocated(e)) then
-    call fail(e%msg)
+    call fail(e%message())
   else if (v1%to_string() /= '1.0.988') then
     call fail("Parsing failed for '"//v1%to_string()//"'")
   end if
 
   call v1%parse('.1.', e)
   if (allocated(e)) then
-    call fail(e%msg)
+    call fail(e%message())
   else if (v1%to_string() /= '0.1.0') then
     call fail("Parsing failed for '"//v1%to_string()//"'")
   end if
 
   call v1%parse('..', e)
   if (allocated(e)) then
-    call fail(e%msg)
+    call fail(e%message())
   else if (v1%to_string() /= '0.0.0') then
     call fail("Parsing failed for '"//v1%to_string()//"'")
   end if
@@ -350,63 +339,63 @@ program test
 
   call v1%parse('1-1', e)
   if (allocated(e)) then
-    call fail(e%msg)
+    call fail(e%message())
   else if (v1%to_string() /= '1.0.0-1') then
     call fail("Parsing failed for '"//v1%to_string()//"'")
   end if
 
   call v1%parse('8.1-1', e)
   if (allocated(e)) then
-    call fail(e%msg)
+    call fail(e%message())
   else if (v1%to_string() /= '8.1.0-1') then
     call fail("Parsing failed for '"//v1%to_string()//"'")
   end if
 
   call v1%parse('1-1.1', e)
   if (allocated(e)) then
-    call fail(e%msg)
+    call fail(e%message())
   else if (v1%to_string() /= '1.0.0-1.1') then
     call fail("Parsing failed for '"//v1%to_string()//"'")
   end if
 
   call v1%parse('8.1-1.9-9--.2', e)
   if (allocated(e)) then
-    call fail(e%msg)
+    call fail(e%message())
   else if (v1%to_string() /= '8.1.0-1.9-9--.2') then
     call fail("Parsing failed for '"//v1%to_string()//"'")
   end if
 
   call v1%parse('1+1', e)
   if (allocated(e)) then
-    call fail(e%msg)
+    call fail(e%message())
   else if (v1%to_string() /= '1.0.0+1') then
     call fail("Parsing failed for '"//v1%to_string()//"'")
   end if
 
   call v1%parse('1+1.1-0P.2', e)
   if (allocated(e)) then
-    call fail(e%msg)
+    call fail(e%message())
   else if (v1%to_string() /= '1.0.0+1.1-0P.2') then
     call fail("Parsing failed for '"//v1%to_string()//"'")
   end if
 
   call v1%parse('1+f-1', e)
   if (allocated(e)) then
-    call fail(e%msg)
+    call fail(e%message())
   else if (v1%to_string() /= '1.0.0+f-1') then
     call fail("Parsing failed for '"//v1%to_string()//"'")
   end if
 
   call v1%parse('1-23+1-1', e)
   if (allocated(e)) then
-    call fail(e%msg)
+    call fail(e%message())
   else if (v1%to_string() /= '1.0.0-23+1-1') then
     call fail("Parsing failed for '"//v1%to_string()//"'")
   end if
 
   call v1%parse('1.0.1-43.fs23+1-1', e)
   if (allocated(e)) then
-    call fail(e%msg)
+    call fail(e%message())
   else if (v1%to_string() /= '1.0.1-43.fs23+1-1') then
     call fail("Parsing failed for '"//v1%to_string()//"'")
   end if
@@ -439,7 +428,7 @@ program test
 
   call v1%parse('1.0.0-RC-X+build-X', e)
   if (allocated(e)) then
-    call fail(e%msg)
+    call fail(e%message())
   else if (v1%to_string() /= '1.0.0-RC-X+build-X') then
     call fail("Parsing failed for '"//v1%to_string()//"'")
   end if
@@ -1248,383 +1237,27 @@ program test
   if (v1%satisfies('>0.0.99 <0.1.0 || >0.1.0')) call fail('satisfies-9 should fail.')
   if (.not. v1%satisfies('<0.0.1 || >0.1.0-123')) call fail('satisfies-10 should not fail.')
 
-!################################satisfies_comp################################!
+!############################ parsed version ranges ############################!
 
-  v1 = version_t(0, 1, 0)
-  call v1%satisfies_comp(comparator_t('abc', version_t(1)), is_satisfied, e)
-  if (.not. allocated(e)) call fail('try_satisfy-comp-1 should fail.')
-  if (is_satisfied) call fail('try_satisfy-comp-1 should not be true.')
+  call range%parse('>=1.0.0 <2.0.0 || =3.0.0', e)
+  if (allocated(e)) call fail(e%message())
 
-  call v1%satisfies_comp(comparator_t('=', version_t(1)), is_satisfied, e)
-  if (allocated(e)) call fail('try_satisfy-comp-2 should not fail.')
-  if (is_satisfied) call fail('try_satisfy-comp-2 should not be true.')
-  call v1%satisfies_comp(comparator_t('', version_t(1)), is_satisfied, e)
-  if (allocated(e)) call fail('try_satisfy-comp-3 should not fail.')
-  if (is_satisfied) call fail('try_satisfy-comp-3 should not be true.')
-  call v1%satisfies_comp(comparator_t('!=', version_t(1)), is_satisfied, e)
-  if (allocated(e)) call fail('try_satisfy-comp-4 should not fail.')
-  if (.not. is_satisfied) call fail('try_satisfy-comp-4 should be true.')
-  call v1%satisfies_comp(comparator_t('>', version_t(1)), is_satisfied, e)
-  if (allocated(e)) call fail('try_satisfy-comp-5 should not fail.')
-  if (is_satisfied) call fail('try_satisfy-comp-5 should not be true.')
-  call v1%satisfies_comp(comparator_t('>=', version_t(1)), is_satisfied, e)
-  if (allocated(e)) call fail('try_satisfy-comp-6 should not fail.')
-  if (is_satisfied) call fail('try_satisfy-comp-6 should not be true.')
-  call v1%satisfies_comp(comparator_t('<', version_t(1)), is_satisfied, e)
-  if (allocated(e)) call fail('try_satisfy-comp-7 should not fail.')
-  if (.not. is_satisfied) call fail('try_satisfy-comp-7 should be true.')
-  call v1%satisfies_comp(comparator_t('<=', version_t(1)), is_satisfied, e)
-  if (allocated(e)) call fail('try_satisfy-comp-8 should not fail.')
-  if (.not. is_satisfied) call fail('try_satisfy-comp-8 should be true.')
+  call range%try_satisfy(version_t(1, 5, 0), is_satisfied, e)
+  if (allocated(e)) call fail(e%message())
+  if (.not. is_satisfied) call fail('Parsed range should satisfy 1.5.0')
 
-  call v1%satisfies_comp(comparator_t('=', version_t(0, 0, 9)), is_satisfied, e)
-  if (allocated(e)) call fail('try_satisfy-comp-9 should not fail.')
-  if (is_satisfied) call fail('try_satisfy-comp-9 should not be true.')
-  call v1%satisfies_comp(comparator_t('', version_t(0, 0, 9)), is_satisfied, e)
-  if (allocated(e)) call fail('try_satisfy-comp-10 should not fail.')
-  if (is_satisfied) call fail('try_satisfy-comp-10 should not be true.')
-  call v1%satisfies_comp(comparator_t('!=', version_t(0, 0, 9)), is_satisfied, e)
-  if (allocated(e)) call fail('try_satisfy-comp-11 should not fail.')
-  if (.not. is_satisfied) call fail('try_satisfy-comp-11 should be true.')
-  call v1%satisfies_comp(comparator_t('>', version_t(0, 0, 9)), is_satisfied, e)
-  if (allocated(e)) call fail('try_satisfy-comp-12 should not fail.')
-  if (.not. is_satisfied) call fail('try_satisfy-comp-12 should be true.')
-  call v1%satisfies_comp(comparator_t('>=', version_t(0, 0, 9)), is_satisfied, e)
-  if (allocated(e)) call fail('try_satisfy-comp-13 should not fail.')
-  if (.not. is_satisfied) call fail('try_satisfy-comp-13 should be true.')
-  call v1%satisfies_comp(comparator_t('<', version_t(0, 0, 9)), is_satisfied, e)
-  if (allocated(e)) call fail('try_satisfy-comp-14 should not fail.')
-  if (is_satisfied) call fail('try_satisfy-comp-14 should not be true.')
-  call v1%satisfies_comp(comparator_t('<=', version_t(0, 0, 9)), is_satisfied, e)
-  if (allocated(e)) call fail('try_satisfy-comp-15 should not fail.')
-  if (is_satisfied) call fail('try_satisfy-comp-15 should not be true.')
-
-  call v1%satisfies_comp(comparator_t('=', version_t(0, 1, 0)), is_satisfied, e)
-  if (allocated(e)) call fail('try_satisfy-comp-16 should not fail.')
-  if (.not. is_satisfied) call fail('try_satisfy-comp-16 should be true.')
-  call v1%satisfies_comp(comparator_t('', version_t(0, 1, 0)), is_satisfied, e)
-  if (allocated(e)) call fail('try_satisfy-comp-17 should not fail.')
-  if (.not. is_satisfied) call fail('try_satisfy-comp-17 should be true.')
-  call v1%satisfies_comp(comparator_t('!=', version_t(0, 1, 0)), is_satisfied, e)
-  if (allocated(e)) call fail('try_satisfy-comp-18 should not fail.')
-  if (is_satisfied) call fail('try_satisfy-comp-18 should not be true.')
-  call v1%satisfies_comp(comparator_t('>', version_t(0, 1, 0)), is_satisfied, e)
-  if (allocated(e)) call fail('try_satisfy-comp-19 should not fail.')
-  if (is_satisfied) call fail('try_satisfy-comp-19 should not be true.')
-  call v1%satisfies_comp(comparator_t('>=', version_t(0, 1, 0)), is_satisfied, e)
-  if (allocated(e)) call fail('try_satisfy-comp-20 should not fail.')
-  if (.not. is_satisfied) call fail('try_satisfy-comp-20 should be true.')
-  call v1%satisfies_comp(comparator_t('<', version_t(0, 1, 0)), is_satisfied, e)
-  if (allocated(e)) call fail('try_satisfy-comp-21 should not fail.')
-  if (is_satisfied) call fail('try_satisfy-comp-21 should not be true.')
-  call v1%satisfies_comp(comparator_t('<=', version_t(0, 1, 0)), is_satisfied, e)
-  if (allocated(e)) call fail('try_satisfy-comp-22 should not fail.')
-  if (.not. is_satisfied) call fail('try_satisfy-comp-22 should be true.')
-
-  call v1%satisfies_comp(comparator_t('=', version_t(0, 1, 0, 'abc')), is_satisfied, e)
-  if (allocated(e)) call fail('try_satisfy-comp-23 should not fail.')
-  if (is_satisfied) call fail('try_satisfy-comp-23 should not be true.')
-  call v1%satisfies_comp(comparator_t('', version_t(0, 1, 0, 'abc')), is_satisfied, e)
-  if (allocated(e)) call fail('try_satisfy-comp-24 should not fail.')
-  if (is_satisfied) call fail('try_satisfy-comp-24 should not be true.')
-  call v1%satisfies_comp(comparator_t('!=', version_t(0, 1, 0, 'abc')), is_satisfied, e)
-  if (allocated(e)) call fail('try_satisfy-comp-25 should not fail.')
-  if (.not. is_satisfied) call fail('try_satisfy-comp-25 should be true.')
-  call v1%satisfies_comp(comparator_t('>', version_t(0, 1, 0, 'abc')), is_satisfied, e)
-  if (allocated(e)) call fail('try_satisfy-comp-26 should not fail.')
-  if (.not. is_satisfied) call fail('try_satisfy-comp-26 should be true.')
-  call v1%satisfies_comp(comparator_t('>=', version_t(0, 1, 0, 'abc')), is_satisfied, e)
-  if (allocated(e)) call fail('try_satisfy-comp-27 should not fail.')
-  if (.not. is_satisfied) call fail('try_satisfy-comp-27 should be true.')
-  call v1%satisfies_comp(comparator_t('<', version_t(0, 1, 0, 'abc')), is_satisfied, e)
-  if (allocated(e)) call fail('try_satisfy-comp-28 should not fail.')
-  if (is_satisfied) call fail('try_satisfy-comp-28 should not be true.')
-  call v1%satisfies_comp(comparator_t('<=', version_t(0, 1, 0, 'abc')), is_satisfied, e)
-  if (allocated(e)) call fail('try_satisfy-comp-29 should not fail.')
-  if (is_satisfied) call fail('try_satisfy-comp-29 should not be true.')
-
-  call v1%satisfies_comp(comparator_t('=', version_t(0, 1, 0, build='1')), is_satisfied, e)
-  if (allocated(e)) call fail('try_satisfy-comp-30 should not fail.')
-  if (.not. is_satisfied) call fail('try_satisfy-comp-30 should be true.')
-  call v1%satisfies_comp(comparator_t('', version_t(0, 1, 0, build='1')), is_satisfied, e)
-  if (allocated(e)) call fail('try_satisfy-comp-31 should not fail.')
-  if (.not. is_satisfied) call fail('try_satisfy-comp-31 should be true.')
-  call v1%satisfies_comp(comparator_t('!=', version_t(0, 1, 0, build='1')), is_satisfied, e)
-  if (allocated(e)) call fail('try_satisfy-comp-32 should not fail.')
-  if (is_satisfied) call fail('try_satisfy-comp-32 should not be true.')
-  call v1%satisfies_comp(comparator_t('>', version_t(0, 1, 0, build='1')), is_satisfied, e)
-  if (allocated(e)) call fail('try_satisfy-comp-33 should not fail.')
-  if (is_satisfied) call fail('try_satisfy-comp-33 should not be true.')
-  call v1%satisfies_comp(comparator_t('>=', version_t(0, 1, 0, build='1')), is_satisfied, e)
-  if (allocated(e)) call fail('try_satisfy-comp-34 should not fail.')
-  if (.not. is_satisfied) call fail('try_satisfy-comp-34 should be true.')
-  call v1%satisfies_comp(comparator_t('<', version_t(0, 1, 0, build='1')), is_satisfied, e)
-  if (allocated(e)) call fail('try_satisfy-comp-35 should not fail.')
-  if (is_satisfied) call fail('try_satisfy-comp-35 should not be true.')
-  call v1%satisfies_comp(comparator_t('<=', version_t(0, 1, 0, build='1')), is_satisfied, e)
-  if (allocated(e)) call fail('try_satisfy-comp-36 should not fail.')
-  if (.not. is_satisfied) call fail('try_satisfy-comp-36 should be true.')
-
-!##############################satisfies_comp_set##############################!
-
-  v1 = version_t(0, 1, 0)
-
-  if (allocated(comps)) deallocate (comps)
-  allocate (comps(0))
-  call v1%satisfies_comp_set(comparator_set_t(comps), is_satisfied, e)
-  if (.not. allocated(e)) call fail('try_satisfy-comp-set-1 should fail.')
-
-  comps = [comparator_t('=', version_t(0, 1, 0))]
-  call v1%satisfies_comp_set(comparator_set_t(comps), is_satisfied, e)
-  if (.not. is_satisfied) call fail('try_satisfy-comp-set-2 should satisfy.')
-  if (allocated(e)) call fail('try_satisfy-comp-set-2 should not fail.')
-  comps = [comparator_t('', version_t(0, 1, 0))]
-  call v1%satisfies_comp_set(comparator_set_t(comps), is_satisfied, e)
-  if (.not. is_satisfied) call fail('try_satisfy-comp-set-2 should satisfy.')
-  if (allocated(e)) call fail('try_satisfy-comp-set-2 should not fail.')
-  comps = [comparator_t('!=', version_t(0, 1, 0))]
-  call v1%satisfies_comp_set(comparator_set_t(comps), is_satisfied, e)
-  if (is_satisfied) call fail('try_satisfy-comp-set-3 should not satisfy.')
-  if (allocated(e)) call fail('try_satisfy-comp-set-3 should not fail.')
-  comps = [comparator_t('>', version_t(0, 1, 0))]
-  call v1%satisfies_comp_set(comparator_set_t(comps), is_satisfied, e)
-  if (is_satisfied) call fail('try_satisfy-comp-set-4 should not satisfy.')
-  if (allocated(e)) call fail('try_satisfy-comp-set-4 should not fail.')
-  comps = [comparator_t('>=', version_t(0, 1, 0))]
-  call v1%satisfies_comp_set(comparator_set_t(comps), is_satisfied, e)
-  if (.not. is_satisfied) call fail('try_satisfy-comp-set-5 should satisfy.')
-  if (allocated(e)) call fail('try_satisfy-comp-set-5 should not fail.')
-  comps = [comparator_t('<', version_t(0, 1, 0))]
-  call v1%satisfies_comp_set(comparator_set_t(comps), is_satisfied, e)
-  if (is_satisfied) call fail('try_satisfy-comp-set-6 should not satisfy.')
-  if (allocated(e)) call fail('try_satisfy-comp-set-6 should not fail.')
-  comps = [comparator_t('<=', version_t(0, 1, 0))]
-  call v1%satisfies_comp_set(comparator_set_t(comps), is_satisfied, e)
-  if (.not. is_satisfied) call fail('try_satisfy-comp-set-7 should satisfy.')
-  if (allocated(e)) call fail('try_satisfy-comp-set-7 should not fail.')
-
-  comps = [comparator_t('=', version_t(1))]
-  call v1%satisfies_comp_set(comparator_set_t(comps), is_satisfied, e)
-  if (is_satisfied) call fail('try_satisfy-comp-set-8 should not satisfy.')
-  if (allocated(e)) call fail('try_satisfy-comp-set-8 should not fail.')
-  comps = [comparator_t('', version_t(1))]
-  call v1%satisfies_comp_set(comparator_set_t(comps), is_satisfied, e)
-  if (is_satisfied) call fail('try_satisfy-comp-set-8 should not satisfy.')
-  if (allocated(e)) call fail('try_satisfy-comp-set-8 should not fail.')
-  comps = [comparator_t('!=', version_t(1))]
-  call v1%satisfies_comp_set(comparator_set_t(comps), is_satisfied, e)
-  if (.not. is_satisfied) call fail('try_satisfy-comp-set-9 should satisfy.')
-  if (allocated(e)) call fail('try_satisfy-comp-set-9 should not fail.')
-  comps = [comparator_t('>', version_t(1))]
-  call v1%satisfies_comp_set(comparator_set_t(comps), is_satisfied, e)
-  if (is_satisfied) call fail('try_satisfy-comp-set-10 should not satisfy.')
-  if (allocated(e)) call fail('try_satisfy-comp-set-10 should not fail.')
-  comps = [comparator_t('>=', version_t(1))]
-  call v1%satisfies_comp_set(comparator_set_t(comps), is_satisfied, e)
-  if (is_satisfied) call fail('try_satisfy-comp-set-11 should not satisfy.')
-  if (allocated(e)) call fail('try_satisfy-comp-set-11 should not fail.')
-  comps = [comparator_t('<', version_t(1))]
-  call v1%satisfies_comp_set(comparator_set_t(comps), is_satisfied, e)
-  if (.not. is_satisfied) call fail('try_satisfy-comp-set-12 should satisfy.')
-  if (allocated(e)) call fail('try_satisfy-comp-set-12 should not fail.')
-  comps = [comparator_t('<=', version_t(1))]
-  call v1%satisfies_comp_set(comparator_set_t(comps), is_satisfied, e)
-  if (.not. is_satisfied) call fail('try_satisfy-comp-set-13 should satisfy.')
-  if (allocated(e)) call fail('try_satisfy-comp-set-13 should not fail.')
-
-  comps = [comparator_t('!=', version_t(1)), comparator_t('>', version_t(0, 9))]
-  call v1%satisfies_comp_set(comparator_set_t(comps), is_satisfied, e)
-  if (is_satisfied) call fail('try_satisfy-comp-set-14 should not satisfy.')
-  if (allocated(e)) call fail('try_satisfy-comp-set-14 should not fail.')
-
-  comps = [comparator_t('=', version_t(1)), comparator_t('<', version_t(0, 9))]
-  call v1%satisfies_comp_set(comparator_set_t(comps), is_satisfied, e)
-  if (is_satisfied) call fail('try_satisfy-comp-set-15 should not satisfy.')
-  if (allocated(e)) call fail('try_satisfy-comp-set-15 should not fail.')
-
-  comps = [comparator_t('', version_t(1)), comparator_t('>', version_t(0, 9))]
-  call v1%satisfies_comp_set(comparator_set_t(comps), is_satisfied, e)
-  if (is_satisfied) call fail('try_satisfy-comp-set-16 should not satisfy.')
-  if (allocated(e)) call fail('try_satisfy-comp-set-16 should not fail.')
-
-  comps = [comparator_t('!=', version_t(1)), comparator_t('<', version_t(0, 9))]
-  call v1%satisfies_comp_set(comparator_set_t(comps), is_satisfied, e)
-  if (.not. is_satisfied) call fail('try_satisfy-comp-set-17 should satisfy.')
-  if (allocated(e)) call fail('try_satisfy-comp-set-17 should not fail.')
-
-  comps = [comparator_t('', version_t(1)), comparator_t('', version_t(2))]
-  call v1%satisfies_comp_set(comparator_set_t(comps), is_satisfied, e)
-  if (is_satisfied) call fail('try_satisfy-comp-set-18 should not satisfy.')
-  if (allocated(e)) call fail('try_satisfy-comp-set-18 should not fail.')
-
-  comps = [comparator_t('', version_t(0, 1)), comparator_t('', version_t(1))]
-  call v1%satisfies_comp_set(comparator_set_t(comps), is_satisfied, e)
-  if (is_satisfied) call fail('try_satisfy-comp-set-19 should not satisfy.')
-  if (allocated(e)) call fail('try_satisfy-comp-set-19 should not fail.')
-
-  comps = [comparator_t('', version_t(1)), comparator_t('', version_t(0, 1))]
-  call v1%satisfies_comp_set(comparator_set_t(comps), is_satisfied, e)
-  if (is_satisfied) call fail('try_satisfy-comp-set-20 should not satisfy.')
-  if (allocated(e)) call fail('try_satisfy-comp-set-20 should not fail.')
-
-  comps = [comparator_t('!=', version_t(1)), comparator_t('', version_t(0, 1))]
-  call v1%satisfies_comp_set(comparator_set_t(comps), is_satisfied, e)
-  if (.not. is_satisfied) call fail('try_satisfy-comp-set-21 should satisfy.')
-  if (allocated(e)) call fail('try_satisfy-comp-set-21 should not fail.')
-
-  comps = [comparator_t('<', version_t(0, 1)), comparator_t('', version_t(0, 1)), comparator_t('>', version_t(2))]
-  call v1%satisfies_comp_set(comparator_set_t(comps), is_satisfied, e)
-  if (is_satisfied) call fail('try_satisfy-comp-set-22 should not satisfy.')
-  if (allocated(e)) call fail('try_satisfy-comp-set-22 should not fail.')
-
-!################################parse_comp_set################################!
-
-  call comp_set%parse('abc', e)
-  if (.not. allocated(e)) call fail('parse-comp-set-1 should fail.')
-
-  call comp_set%parse('>0.0.1', e)
-  if (comp_set%comps(1)%op /= '>') call fail("parse-comp-set-2: Wrong operator parsed.")
-  if (comp_set%comps(1)%version /= version_t(0, 0, 1)) call fail('parse-comp-set-2: Version does not match.')
-  if (allocated(e)) call fail('parse-comp-set-2 should not fail.')
-
-  call comp_set%parse('> 0.0.1', e)
-  if (comp_set%comps(1)%op /= '>') call fail("parse-comp-set-3: Wrong operator parsed.")
-  if (comp_set%comps(1)%version /= version_t(0, 0, 1)) call fail('parse-comp-set-3: Version does not match.')
-  if (allocated(e)) call fail('parse-comp-set-3 should not fail.')
-
-  call comp_set%parse('1', e)
-  if (comp_set%comps(1)%op /= '') call fail("parse-comp-set-4: Wrong operator parsed.")
-  if (comp_set%comps(1)%version /= version_t(1)) call fail('parse-comp-set-4: Version does not match.')
-  if (allocated(e)) call fail('parse-comp-set-4 should not fail.')
-
-  call comp_set%parse('1.0.0 1.0.1', e)
-  if (comp_set%comps(1)%op /= '') call fail("parse-comp-set-5: Wrong operator parsed.")
-  if (comp_set%comps(1)%version /= version_t(1)) call fail('parse-comp-set-5: Version does not match.')
-  if (comp_set%comps(2)%op /= '') call fail("parse-comp-set-5: Wrong operator parsed.")
-  if (comp_set%comps(2)%version /= version_t(1, 0, 1)) call fail('parse-comp-set-5: Version does not match.')
-  if (allocated(e)) call fail('parse-comp-set-5 should not fail.')
-
-  call comp_set%parse('=1.0.0 !=1.0.1', e)
-  if (comp_set%comps(1)%op /= '=') call fail("parse-comp-set-6: Wrong operator parsed.")
-  if (comp_set%comps(1)%version /= version_t(1)) call fail('parse-comp-set-6: Version does not match.')
-  if (comp_set%comps(2)%op /= '!=') call fail("parse-comp-set-6: Wrong operator parsed.")
-  if (comp_set%comps(2)%version /= version_t(1, 0, 1)) call fail('parse-comp-set-6: Version does not match.')
-  if (allocated(e)) call fail('parse-comp-set-6 should not fail.')
-
-  call comp_set%parse('<  1.0.0 > 1.0.1 =2', e)
-  if (size(comp_set%comps) /= 3) call fail("parse-comp-set-7: Wrong number of comparators.")
-  if (comp_set%comps(1)%op /= '<') call fail("parse-comp-set-7: Wrong operator parsed.")
-  if (comp_set%comps(1)%version /= version_t(1)) call fail('parse-comp-set-7: Version does not match.')
-  if (comp_set%comps(2)%op /= '>') call fail("parse-comp-set-7: Wrong operator parsed.")
-  if (comp_set%comps(2)%version /= version_t(1, 0, 1)) call fail('parse-comp-set-7: Version does not match.')
-  if (comp_set%comps(3)%op /= '=') call fail("parse-comp-set-7: Wrong operator parsed.")
-  if (comp_set%comps(3)%version /= version_t(2)) call fail('parse-comp-set-7: Version does not match.')
-  if (allocated(e)) call fail('parse-comp-set-7 should not fail.')
-
-  call comp_set%parse('  > 1.0.1 <  2.1.0 ', e)
-  if (size(comp_set%comps) /= 2) call fail("parse-comp-set-8: Wrong number of comparators.")
-  if (comp_set%comps(1)%op /= '>') call fail("parse-comp-set-8: Wrong operator parsed.")
-  if (comp_set%comps(1)%version /= version_t(1, 0, 1)) call fail('parse-comp-set-8: Version does not match.')
-  if (comp_set%comps(2)%op /= '<') call fail("parse-comp-set-8: Wrong operator parsed.")
-  if (comp_set%comps(2)%version /= version_t(2, 1, 0)) call fail('parse-comp-set-8: Version does not match.')
-  if (allocated(e)) call fail('parse-comp-set-8 should not fail.')
-
-  call comp_set%parse('  >= 1.0.1 <=  2.1.0 ', e)
-  if (size(comp_set%comps) /= 2) call fail("parse-comp-set-9: Wrong number of comparators.")
-  if (comp_set%comps(1)%op /= '>=') call fail("parse-comp-set-9: Wrong operator parsed.")
-  if (comp_set%comps(1)%version /= version_t(1, 0, 1)) call fail('parse-comp-set-9: Version does not match.')
-  if (comp_set%comps(2)%op /= '<=') call fail("parse-comp-set-9: Wrong operator parsed.")
-  if (comp_set%comps(2)%version /= version_t(2, 1, 0)) call fail('parse-comp-set-9: Version does not match.')
-  if (allocated(e)) call fail('parse-comp-set-9 should not fail.')
-
-  ! Regression tests for scanners reaching the end of the input. Fortran does
-  ! not guarantee short-circuit evaluation in bounds-checking expressions.
-  call comp_set%parse('0.0.1', e)
-  if (allocated(e)) call fail('parse-comp-set-10 should not fail.')
-  if (size(comp_set%comps) /= 1) call fail("parse-comp-set-10: Wrong number of comparators.")
-  if (comp_set%comps(1)%version /= version_t(0, 0, 1)) call fail('parse-comp-set-10: Version does not match.')
-
-  call comp_set%parse('>=1.2.3', e)
-  if (allocated(e)) call fail('parse-comp-set-11 should not fail.')
-  if (size(comp_set%comps) /= 1) call fail("parse-comp-set-11: Wrong number of comparators.")
-  if (comp_set%comps(1)%op /= '>=') call fail("parse-comp-set-11: Wrong operator parsed.")
-  if (comp_set%comps(1)%version /= version_t(1, 2, 3)) call fail('parse-comp-set-11: Version does not match.')
-
-  call comp_set%parse('> 1.2.3', e)
-  if (allocated(e)) call fail('parse-comp-set-12 should not fail.')
-  if (size(comp_set%comps) /= 1) call fail("parse-comp-set-12: Wrong number of comparators.")
-  if (comp_set%comps(1)%op /= '>') call fail("parse-comp-set-12: Wrong operator parsed.")
-  if (comp_set%comps(1)%version /= version_t(1, 2, 3)) call fail('parse-comp-set-12: Version does not match.')
-
-!##############################parse_version_range#############################!
+  if (.not. range%satisfies(version_t(3, 0, 0))) call fail('Parsed range should satisfy 3.0.0')
+  if (range%satisfies(version_t(2, 0, 0))) call fail('Parsed range should not satisfy 2.0.0')
 
   call range%parse('', e)
-  if (.not. allocated(e)) call fail('parse-version-range-1 should fail.')
+  if (.not. allocated(e)) call fail('Empty parsed range should report an error')
 
-  call range%parse('abc', e)
-  if (.not. allocated(e)) call fail('parse-version-range-2 should fail.')
-
-  call range%parse('abc||abc', e)
-  if (.not. allocated(e)) call fail('parse-version-range-3 should fail.')
-
-  call range%parse('abc||', e)
-  if (.not. allocated(e)) call fail('parse-version-range-4 should fail.')
-
-  call range%parse('||abc', e)
-  if (.not. allocated(e)) call fail('parse-version-range-5 should fail.')
-
-  call range%parse('||', e)
-  if (.not. allocated(e)) call fail('parse-version-range-6 should fail.')
-
-  call range%parse('0.2.0', e)
-  if (size(range%comp_sets) /= 1) call fail('parse-version-range-7 has wrong number of sets.')
-  if (range%comp_sets(1)%comps(1)%op /= '') call fail('parse-version-range-7: Wrong operator.')
-  if (range%comp_sets(1)%comps(1)%version /= version_t(0, 2)) call fail('parse-version-range-7: Wrong version.')
-  if (allocated(e)) call fail('parse-version-range-7 should not fail.')
-
-  call range%parse('0.2.0 || 0.3.0', e)
-  if (size(range%comp_sets) /= 2) call fail('parse-version-range-8 has wrong number of sets.')
-  if (range%comp_sets(1)%comps(1)%op /= '') call fail('parse-version-range-8: Wrong operator.')
-  if (range%comp_sets(1)%comps(1)%version /= version_t(0, 2)) call fail('parse-version-range-8: Wrong version.')
-  if (range%comp_sets(2)%comps(1)%op /= '') call fail('parse-version-range-8: Wrong operator.')
-  if (range%comp_sets(2)%comps(1)%version /= version_t(0, 3)) call fail('parse-version-range-8: Wrong version.')
-  if (allocated(e)) call fail('parse-version-range-8 should not fail.')
-
-  call range%parse('0.2.0 || <0.3.0 || >= 0.4.0', e)
-  if (size(range%comp_sets) /= 3) call fail('parse-version-range-9 has wrong number of sets.')
-  if (range%comp_sets(1)%comps(1)%op /= '') call fail('parse-version-range-9 has parsed the wrong operator.')
-  if (range%comp_sets(1)%comps(1)%version /= version_t(0, 2)) call fail('parse-version-range-9 has parsed the wrong version.')
-  if (range%comp_sets(2)%comps(1)%op /= '<') call fail('parse-version-range-9 has parsed the wrong operator.')
-  if (range%comp_sets(2)%comps(1)%version /= version_t(0, 3)) call fail('parse-version-range-9 has parsed the wrong version.')
-  if (range%comp_sets(3)%comps(1)%op /= '>=') call fail('parse-version-range-9 has parsed the wrong operator.')
-  if (range%comp_sets(3)%comps(1)%version /= version_t(0, 4)) call fail('parse-version-range-9 has parsed the wrong version.')
-  if (allocated(e)) call fail('parse-version-range-9 should not fail.')
-
-  call range%parse('0.2.0 <0.3.0 || >= 0.4.0 !=0.4.1 =0.5.0 || 0.6.0', e)
-  if (size(range%comp_sets) /= 3) call fail('parse-version-range-10 has wrong number of sets.')
-  if (range%comp_sets(1)%comps(1)%op /= '') call fail('parse-version-range-10: Wrong operator.')
-  if (range%comp_sets(1)%comps(1)%version /= version_t(0, 2)) call fail('parse-version-range-10: Wrong version.')
-  if (range%comp_sets(1)%comps(2)%op /= '<') call fail('parse-version-range-10: Wrong operator.')
-  if (range%comp_sets(1)%comps(2)%version /= version_t(0, 3)) call fail('parse-version-range-10: Wrong version.')
-  if (range%comp_sets(2)%comps(1)%op /= '>=') call fail('parse-version-range-10: Wrong operator.')
-  if (range%comp_sets(2)%comps(1)%version /= version_t(0, 4)) call fail('parse-version-range-10: Wrong version.')
-  if (range%comp_sets(2)%comps(2)%op /= '!=') call fail('parse-version-range-10: Wrong operator.')
-  if (range%comp_sets(2)%comps(2)%version /= version_t(0, 4, 1)) call fail('parse-version-range-10: Wrong version.')
-  if (range%comp_sets(2)%comps(3)%op /= '=') call fail('parse-version-range-10: Wrong operator.')
-  if (range%comp_sets(2)%comps(3)%version /= version_t(0, 5)) call fail('parse-version-range-10: Wrong version.')
-  if (range%comp_sets(3)%comps(1)%op /= '') call fail('parse-version-range-10: Wrong operator.')
-  if (range%comp_sets(3)%comps(1)%version /= version_t(0, 6)) call fail('parse-version-range-10: Wrong version.')
-  if (allocated(e)) call fail('parse-version-range-10 should not fail.')
-
-  call range%parse('0.2.0 0.2.1 0.3.0', e)
-  if (size(range%comp_sets) /= 1) call fail('parse-version-range-11 has wrong number of sets.')
-  if (range%comp_sets(1)%comps(1)%op /= '') call fail('parse-version-range-11: Wrong operator.')
-  if (range%comp_sets(1)%comps(1)%version /= version_t(0, 2)) call fail('parse-version-range-11: Wrong version.')
-  if (range%comp_sets(1)%comps(2)%op /= '') call fail('parse-version-range-11: Wrong operator.')
-  if (range%comp_sets(1)%comps(2)%version /= version_t(0, 2, 1)) call fail('parse-version-range-11: Wrong version.')
-  if (range%comp_sets(1)%comps(3)%op /= '') call fail('parse-version-range-11: Wrong operator.')
-  if (range%comp_sets(1)%comps(3)%version /= version_t(0, 3)) call fail('parse-version-range-11: Wrong version.')
-  if (allocated(e)) call fail('parse-version-range-11 should not fail.')
+  block
+    type(version_range_t) :: unparsed_range
+    call unparsed_range%try_satisfy(version_t(1), is_satisfied, e)
+    if (.not. allocated(e)) call fail('Unparsed range should report an error')
+    if (unparsed_range%satisfies(version_t(1))) call fail('Unparsed range should not satisfy a version')
+  end block
 
 !###################################is_stable##################################!
 
@@ -1737,24 +1370,24 @@ program test
 !###################### parse with whitespace ################################!
 
   call v1%parse('  1.0.0  ', e)
-  if (allocated(e)) call fail(e%msg)
+  if (allocated(e)) call fail(e%message())
   if (v1%to_string() /= '1.0.0') call fail('parse should trim whitespace')
 
   call v1%parse('  1.0.0-alpha  ', e)
-  if (allocated(e)) call fail(e%msg)
+  if (allocated(e)) call fail(e%message())
   if (v1%to_string() /= '1.0.0-alpha') call fail('parse should trim whitespace with prerelease')
 
   call v1%parse('  1.0.0-alpha+build  ', e)
-  if (allocated(e)) call fail(e%msg)
+  if (allocated(e)) call fail(e%message())
   if (v1%to_string() /= '1.0.0-alpha+build') call fail('parse should trim whitespace with prerelease and build')
 
 !###################### parse strict_mode edge cases ##########################!
 
   call v1%parse('0.0.0-alpha', e, strict_mode=.true.)
-  if (allocated(e)) call fail(e%msg)
+  if (allocated(e)) call fail(e%message())
 
   call v1%parse('0.0.0-alpha+build', e, strict_mode=.true.)
-  if (allocated(e)) call fail(e%msg)
+  if (allocated(e)) call fail(e%message())
 
   call v1%parse('01.2.3', e, strict_mode=.true.)
   if (.not. allocated(e)) call fail('Strict mode: Leading zero in major version.')


### PR DESCRIPTION
- [x] Reduce the public API surface by making `string_t`, `comparator_t`, and `comparator_set_t` private.